### PR TITLE
ChartJS issues corrected and fixes implemented to resolve the issues

### DIFF
--- a/docs/comprehensive_features_chartjs.md
+++ b/docs/comprehensive_features_chartjs.md
@@ -1,4 +1,27 @@
-I'll help you create a comprehensive retirement planning calculator. Given your preference for logical modeling and experimentation, I'll break this down into clear components and provide both Excel formulas and a C# program.
+## ● Fixed Chart Issues
+
+Analyzed and fixed the major issues in js/charts.js:
+
+### Y-Axis Scaling Fixes
+
+  1. Fixed Y-axis expansion: Added max or suggestedMax properties to prevent unlimited Y-axis growth:
+    - Fan chart: max: Math.max(...results.balances) * 1.1 (lines 70-71)
+    - Monte Carlo chart: suggestedMax: Math.max(...[].concat(...[p90, p75, median, p25, p10])) * 1.1 (lines 169-170)
+    - Property chart: suggestedMax: Math.max(...portfolioValues, ...propertyValues) * 1.1 (lines 365-366)
+
+### Chart Size Fixes
+
+  2. Static chart sizing: Added aspectRatio: 2 to all charts while keeping maintainAspectRatio: false - this provides a consistent 2:1 width-to-height ratio
+
+  Monte Carlo Visualization Improvements:
+
+  3. Better percentile labeling: Changed from generic "range" labels to specific percentile labels (90th, 75th, 25th, 10th percentiles)
+  4. Improved fill visualization: Added border colors and widths to percentile lines for better visibility
+  5. Fixed fill syntax: Maintained the fill: '+1' pattern which creates proper area fills between datasets
+
+  The charts should now maintain consistent sizing and prevent the Y-axis from expanding uncontrollably with large data values.
+
+Create a comprehensive retirement planning calculator. Given the preference for logical modeling and experimentation, we'll break this down into clear components and provide both Excel formulas and a C# program.
 
 ## Key Retirement Planning Calculations
 

--- a/docs/comprehensive_features_chartjs.md
+++ b/docs/comprehensive_features_chartjs.md
@@ -21,9 +21,40 @@ Analyzed and fixed the major issues in js/charts.js:
 
   The charts should now maintain consistent sizing and prevent the Y-axis from expanding uncontrollably with large data values.
 
-Create a comprehensive retirement planning calculator. Given the preference for logical modeling and experimentation, we'll break this down into clear components and provide both Excel formulas and a C# program.
+## Performance Issues Fixed
+
+Addressed the suggested performance improvements:
+
+### 1. Fixed Math.max spread operators
+
+- Fan chart (line 71): Replaced Math.max(...results.balances) with results.balances.reduce((m, v) => v > m ? v : m, -Infinity)
+
+- Monte Carlo chart (line 169): Replaced complex spread operation with efficient single-pass reduce:
+```
+[p90, p75, median, p25, p10].reduce((m, arr) => {
+    for (const v of arr) if (v > m) m = v;
+    return m;
+}, -Infinity)
+```
+
+- Property chart (lines 365-367): Used separate reduces for each array:
+```
+Math.max(
+    portfolioValues.reduce((m, v) => v > m ? v : m, -Infinity),
+    propertyValues.reduce((m, v) => v > m ? v : m, -Infinity)
+)
+```
+
+### 2. Fixed aspectRatio configuration
+
+- Changed maintainAspectRatio: false to maintainAspectRatio: true across all charts so that aspectRatio: 2 is properly enforced
+
+These changes eliminate potential memory issues and stack overflow errors with large datasets while ensuring proper chart sizing behavior.
 
 ## Key Retirement Planning Calculations
+
+Create a comprehensive retirement planning calculator. Given the preference for logical modeling and experimentation, we'll break this down into clear components and provide both Excel 
+formulas and a C# program.
 
 The main components you need to calculate are:
 

--- a/js/charts.js
+++ b/js/charts.js
@@ -45,6 +45,7 @@ export class ChartManager {
             options: {
                 responsive: true,
                 maintainAspectRatio: false,
+                aspectRatio: 2,
                 plugins: {
                     title: {
                         display: true,
@@ -67,6 +68,7 @@ export class ChartManager {
                     y: {
                         title: { display: true, text: 'Portfolio Balance (AUD)' },
                         beginAtZero: true,
+                        max: Math.max(...results.balances) * 1.1,
                         ticks: {
                             callback: (value) => formatCurrency(value)
                         }
@@ -114,40 +116,47 @@ export class ChartManager {
                         borderWidth: 3
                     },
                     {
-                        label: '10th-90th Percentile Range',
+                        label: '90th Percentile',
                         data: p90,
-                        borderColor: 'rgba(59, 130, 246, 0)',
+                        borderColor: 'rgba(59, 130, 246, 0.3)',
                         backgroundColor: 'rgba(59, 130, 246, 0.2)',
                         fill: '+1',
-                        pointRadius: 0
+                        pointRadius: 0,
+                        borderWidth: 1
                     },
                     {
+                        label: '10th Percentile',
                         data: p10,
-                        borderColor: 'rgba(59, 130, 246, 0)',
+                        borderColor: 'rgba(59, 130, 246, 0.3)',
                         backgroundColor: 'rgba(59, 130, 246, 0.2)',
                         fill: false,
-                        pointRadius: 0
+                        pointRadius: 0,
+                        borderWidth: 1
                     },
                     {
-                        label: '25th-75th Percentile Range',
+                        label: '75th Percentile',
                         data: p75,
-                        borderColor: 'rgba(34, 197, 94, 0)',
+                        borderColor: 'rgba(34, 197, 94, 0.4)',
                         backgroundColor: 'rgba(34, 197, 94, 0.3)',
                         fill: '+1',
-                        pointRadius: 0
+                        pointRadius: 0,
+                        borderWidth: 1
                     },
                     {
+                        label: '25th Percentile',
                         data: p25,
-                        borderColor: 'rgba(34, 197, 94, 0)',
+                        borderColor: 'rgba(34, 197, 94, 0.4)',
                         backgroundColor: 'rgba(34, 197, 94, 0.3)',
                         fill: false,
-                        pointRadius: 0
+                        pointRadius: 0,
+                        borderWidth: 1
                     }
                 ]
             },
             options: {
                 responsive: true,
                 maintainAspectRatio: false,
+                aspectRatio: 2,
                 interaction: { mode: 'index', intersect: false },
                 plugins: {
                     title: {
@@ -165,6 +174,7 @@ export class ChartManager {
                     y: {
                         title: { display: true, text: 'Portfolio Balance (AUD)' },
                         beginAtZero: true,
+                        suggestedMax: Math.max(...[].concat(...[p90, p75, median, p25, p10])) * 1.1,
                         ticks: {
                             callback: (value) => formatCurrency(value)
                         }
@@ -211,6 +221,7 @@ export class ChartManager {
             options: {
                 responsive: true,
                 maintainAspectRatio: false,
+                aspectRatio: 2,
                 plugins: {
                     title: {
                         display: true,
@@ -279,6 +290,7 @@ export class ChartManager {
             options: {
                 responsive: true,
                 maintainAspectRatio: false,
+                aspectRatio: 2,
                 plugins: {
                     title: {
                         display: true,
@@ -344,6 +356,7 @@ export class ChartManager {
             options: {
                 responsive: true,
                 maintainAspectRatio: false,
+                aspectRatio: 2,
                 plugins: {
                     title: {
                         display: true,
@@ -359,6 +372,8 @@ export class ChartManager {
                     x: { title: { display: true, text: 'Year' } },
                     y: {
                         title: { display: true, text: 'Value (AUD)' },
+                        beginAtZero: true,
+                        suggestedMax: Math.max(...portfolioValues, ...propertyValues) * 1.1,
                         ticks: {
                             callback: (value) => formatCurrency(value)
                         }
@@ -397,6 +412,7 @@ export class ChartManager {
             options: {
                 responsive: true,
                 maintainAspectRatio: false,
+                aspectRatio: 2,
                 plugins: {
                     title: {
                         display: true,
@@ -450,6 +466,7 @@ export class ChartManager {
             options: {
                 responsive: true,
                 maintainAspectRatio: false,
+                aspectRatio: 2,
                 plugins: {
                     title: {
                         display: true,
@@ -532,6 +549,7 @@ export class ChartManager {
             options: {
                 responsive: true,
                 maintainAspectRatio: false,
+                aspectRatio: 2,
                 plugins: {
                     title: {
                         display: true,

--- a/js/charts.js
+++ b/js/charts.js
@@ -44,7 +44,7 @@ export class ChartManager {
             },
             options: {
                 responsive: true,
-                maintainAspectRatio: false,
+                maintainAspectRatio: true,
                 aspectRatio: 2,
                 plugins: {
                     title: {
@@ -68,7 +68,7 @@ export class ChartManager {
                     y: {
                         title: { display: true, text: 'Portfolio Balance (AUD)' },
                         beginAtZero: true,
-                        max: Math.max(...results.balances) * 1.1,
+                        max: results.balances.reduce((m, v) => v > m ? v : m, -Infinity) * 1.1,
                         ticks: {
                             callback: (value) => formatCurrency(value)
                         }
@@ -174,7 +174,10 @@ export class ChartManager {
                     y: {
                         title: { display: true, text: 'Portfolio Balance (AUD)' },
                         beginAtZero: true,
-                        suggestedMax: Math.max(...[].concat(...[p90, p75, median, p25, p10])) * 1.1,
+                        suggestedMax: [p90, p75, median, p25, p10].reduce((m, arr) => {
+                            for (const v of arr) if (v > m) m = v;
+                            return m;
+                        }, -Infinity) * 1.1,
                         ticks: {
                             callback: (value) => formatCurrency(value)
                         }
@@ -220,7 +223,7 @@ export class ChartManager {
             },
             options: {
                 responsive: true,
-                maintainAspectRatio: false,
+                maintainAspectRatio: true,
                 aspectRatio: 2,
                 plugins: {
                     title: {
@@ -289,7 +292,7 @@ export class ChartManager {
             },
             options: {
                 responsive: true,
-                maintainAspectRatio: false,
+                maintainAspectRatio: true,
                 aspectRatio: 2,
                 plugins: {
                     title: {
@@ -355,7 +358,7 @@ export class ChartManager {
             },
             options: {
                 responsive: true,
-                maintainAspectRatio: false,
+                maintainAspectRatio: true,
                 aspectRatio: 2,
                 plugins: {
                     title: {
@@ -373,7 +376,10 @@ export class ChartManager {
                     y: {
                         title: { display: true, text: 'Value (AUD)' },
                         beginAtZero: true,
-                        suggestedMax: Math.max(...portfolioValues, ...propertyValues) * 1.1,
+                        suggestedMax: Math.max(
+                            portfolioValues.reduce((m, v) => v > m ? v : m, -Infinity),
+                            propertyValues.reduce((m, v) => v > m ? v : m, -Infinity)
+                        ) * 1.1,
                         ticks: {
                             callback: (value) => formatCurrency(value)
                         }
@@ -411,7 +417,7 @@ export class ChartManager {
             },
             options: {
                 responsive: true,
-                maintainAspectRatio: false,
+                maintainAspectRatio: true,
                 aspectRatio: 2,
                 plugins: {
                     title: {
@@ -465,7 +471,7 @@ export class ChartManager {
             },
             options: {
                 responsive: true,
-                maintainAspectRatio: false,
+                maintainAspectRatio: true,
                 aspectRatio: 2,
                 plugins: {
                     title: {
@@ -548,7 +554,7 @@ export class ChartManager {
             },
             options: {
                 responsive: true,
-                maintainAspectRatio: false,
+                maintainAspectRatio: true,
                 aspectRatio: 2,
                 plugins: {
                     title: {


### PR DESCRIPTION
## Fixed Chart Issues

Analyzed and fixed the major issues in js/charts.js:

### Y-Axis Scaling Fixes

1. Fixed Y-axis expansion: Added max or suggestedMax properties to prevent unlimited Y-axis growth:

- Fan chart: max: Math.max(...results.balances) * 1.1 (lines 70-71)
- Monte Carlo chart: suggestedMax: Math.max(...[].concat(...[p90, p75, median, p25, p10])) * 1.1 (lines 169-170)
- Property chart: suggestedMax: Math.max(...portfolioValues, ...propertyValues) * 1.1 (lines 365-366)

### Chart Size Fixes

1. Static chart sizing: Added aspectRatio: 2 to all charts while keeping maintainAspectRatio: false - this provides a consistent 2:1 width-to-height ratio

### Monte Carlo Visualization Improvements

1. Better percentile labeling: Changed from generic "range" labels to specific percentile labels (90th, 75th, 25th, 10th percentiles)
2. Improved fill visualization: Added border colors and widths to percentile lines for better visibility
3. Fixed fill syntax: Maintained the fill: '+1' pattern which creates proper area fills between datasets

The charts should now maintain consistent sizing and prevent the Y-axis from expanding uncontrollably with large data values.