### PR TITLE
Fix Application syntax issues

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1073,7 +1073,7 @@
             <div class="space-y-4">
                 <div>
                     <div class="label-with-tooltip">
-                        <label for="yourSalary" class="text-sm font-medium text-gray-700">Your Annual Salary (pre-tax)</label>
+                        <label for="yourSalary" class="text-sm font-medium text-gray-700">Your Annual Salary (pre-tax) ($)</label>
                         <div class="tooltip">
                             <span class="tooltip-icon" aria-label="Salary information">i</span>
                             <span class="tooltiptext">
@@ -1086,12 +1086,12 @@
                     <input type="text" id="yourSalary" value="164000" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
                 </div>
                 <div>
-                    <label for="partnerSalary" class="block text-sm font-medium text-gray-700">Partner's Annual Salary (pre-tax)</label>
+                    <label for="partnerSalary" class="block text-sm font-medium text-gray-700">Partner's Annual Salary (pre-tax) ($)</label>
                     <input type="text" id="partnerSalary" value="124500" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
                 </div>
                 <div>
                     <div class="label-with-tooltip">
-                        <label for="yourCurrentSuper" class="text-sm font-medium text-gray-700">Your Current Superannuation</label>
+                        <label for="yourCurrentSuper" class="text-sm font-medium text-gray-700">Your Current Superannuation ($)</label>
                         <div class="tooltip">
                             <span class="tooltip-icon" aria-label="Super balance information">i</span>
                             <span class="tooltiptext">
@@ -1104,12 +1104,12 @@
                     <input type="text" id="yourCurrentSuper" value="300000" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
                 </div>
                 <div>
-                    <label for="partnerCurrentSuper" class="block text-sm font-medium text-gray-700">Partner's Current Superannuation</label>
+                    <label for="partnerCurrentSuper" class="block text-sm font-medium text-gray-700">Partner's Current Superannuation ($)</label>
                     <input type="text" id="partnerCurrentSuper" value="150000" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
                 </div>
                 <div>
                     <div class="label-with-tooltip">
-                        <label for="currentSavings" class="text-sm font-medium text-gray-700">Current Cash/Savings</label>
+                        <label for="currentSavings" class="text-sm font-medium text-gray-700">Current Cash/Savings ($)</label>
                         <div class="tooltip">
                             <span class="tooltip-icon" aria-label="Savings information">i</span>
                             <span class="tooltiptext">
@@ -1122,11 +1122,11 @@
                     <input type="text" id="currentSavings" value="125000" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
                 </div>
                 <div>
-                    <label for="currentStocks" class="block text-sm font-medium text-gray-700">Current Stock Portfolio</label>
+                    <label for="currentStocks" class="block text-sm font-medium text-gray-700">Current Stock Portfolio ($)</label>
                     <input type="text" id="currentStocks" value="45000" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
                 </div>
                 <div>
-                    <label for="monthlyStockContribution" class="block text-sm font-medium text-gray-700">Monthly Stock Contributions</label>
+                    <label for="monthlyStockContribution" class="block text-sm font-medium text-gray-700">Monthly Stock Contributions ($)</label>
                     <input type="text" id="monthlyStockContribution" value="800" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
                 </div>
                 <div>
@@ -1154,7 +1154,7 @@
             <div class="space-y-4">
                 <div>
                     <div class="label-with-tooltip">
-                        <label for="homeValue" class="text-sm font-medium text-gray-700">Current Home Value</label>
+                        <label for="homeValue" class="text-sm font-medium text-gray-700">Current Home Value ($)</label>
                         <div class="tooltip">
                             <span class="tooltip-icon" aria-label="Home value information">i</span>
                             <span class="tooltiptext">
@@ -1167,7 +1167,7 @@
                     <input type="text" id="homeValue" value="1450000" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
                 </div>
                 <div>
-                    <label for="mortgageBalance" class="block text-sm font-medium text-gray-700">Outstanding Mortgage</label>
+                    <label for="mortgageBalance" class="block text-sm font-medium text-gray-700">Outstanding Mortgage ($)</label>
                     <input type="text" id="mortgageBalance" value="940000" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
                 </div>
                 <div>
@@ -1175,7 +1175,7 @@
                     <input type="text" id="mortgageRate" value="5.37" step="0.01" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
                 </div>
                 <div>
-                    <label for="monthlyMortgagePayment" class="block text-sm font-medium text-gray-700">Monthly Mortgage Payment</label>
+                    <label for="monthlyMortgagePayment" class="block text-sm font-medium text-gray-700">Monthly Mortgage Payment ($)</label>
                     <input type="text" id="monthlyMortgagePayment" value="4984" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
                 </div>
                 <div>
@@ -1208,11 +1208,11 @@
                     </div>
                     <div id="investmentPropertySection">
                         <div>
-                            <label for="investmentPropertyValue" class="block text-sm font-medium text-gray-700">Current Value</label>
+                            <label for="investmentPropertyValue" class="block text-sm font-medium text-gray-700">Current Value ($)</label>
                             <input type="text" id="investmentPropertyValue" value="600000" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
                         </div>
                         <div>
-                            <label for="investmentPropertyLoan" class="block text-sm font-medium text-gray-700">Outstanding Loan</label>
+                            <label for="investmentPropertyLoan" class="block text-sm font-medium text-gray-700">Outstanding Loan ($)</label>
                             <input type="text" id="investmentPropertyLoan" value="574000" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
                         </div>
                         <div>
@@ -1220,11 +1220,11 @@
                             <input type="text" id="investmentPropertyRate" value="6.2" step="0.01" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
                         </div>
                         <div>
-                            <label for="weeklyRentalIncome" class="block text-sm font-medium text-gray-700">Weekly Rental Income</label>
+                            <label for="weeklyRentalIncome" class="block text-sm font-medium text-gray-700">Weekly Rental Income ($)</label>
                             <input type="text" id="weeklyRentalIncome" value="575" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
                         </div>
                         <div>
-                            <label for="annualPropertyExpenses" class="block text-sm font-medium text-gray-700">Annual Property Expenses</label>
+                            <label for="annualPropertyExpenses" class="block text-sm font-medium text-gray-700">Annual Property Expenses ($)</label>
                             <input type="text" id="annualPropertyExpenses" value="9675" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
                         </div>
                         <div>
@@ -1278,7 +1278,7 @@
                         </div>
                         <div>
                             <div class="label-with-tooltip">
-                                <label for="trustNetAssets" class="text-sm font-medium text-gray-700">Current Trust Net Assets Value</label>
+                                <label for="trustNetAssets" class="text-sm font-medium text-gray-700">Current Trust Net Assets Value ($)</label>
                                 <div class="tooltip">
                                     <span class="tooltip-icon" aria-label="Trust assets information">i</span>
                                     <span class="tooltiptext">
@@ -1338,7 +1338,7 @@
                 <h3 class="text-lg font-medium text-gray-700 mb-3">Healthcare & Aged Care</h3>
                 <div class="space-y-3">
                     <div>
-                        <label for="currentHealthcareCosts" class="block text-sm font-medium text-gray-700">Current Annual Healthcare Costs</label>
+                        <label for="currentHealthcareCosts" class="block text-sm font-medium text-gray-700">Current Annual Healthcare Costs ($)</label>
                         <input type="text" id="currentHealthcareCosts" value="5200" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
                     </div>
                     <div>
@@ -1379,7 +1379,7 @@
                     </div>
                     <div>
                         <div class="label-with-tooltip">
-                            <label for="agedCareAnnualCost" class="text-sm font-medium text-gray-700">Annual Aged Care Cost</label>
+                            <label for="agedCareAnnualCost" class="text-sm font-medium text-gray-700">Annual Aged Care Cost ($)</label>
                             <div class="tooltip">
                                 <span class="tooltip-icon" aria-label="Aged care cost information">i</span>
                                 <span class="tooltiptext">


### PR DESCRIPTION
1. On the "Your Enhanced Retirement Summary", the " Risk Tolerance:" field is still showing as "undefined/10". We had corrected this a few sessions ago to show a gradient colour based on the risk tolerance selected during the onboarding process/workflow
2. Can you check all the fields of the advanced/original calculator, and make all the percentage field with the same formatting as the "Annual Mortgage Rate (%)" text field?
3. Also, check all the fields of the advanced/original calculator, and make all the currency field with the same formatting as the "Monthly Mortgage Payment" text field?