### PR TITLE
Fix report calculation regressions

### DIFF
--- a/src/js/healthcare-modeling.js
+++ b/src/js/healthcare-modeling.js
@@ -391,6 +391,17 @@ export class HealthcareModelingEngine {
         return baseAmount * Math.pow(1 + rate, years);
     }
 
+    getUserAgedCareProbability(inputs) {
+        if (inputs.agedCareProbability === undefined || inputs.agedCareProbability === null || inputs.agedCareProbability === '') {
+            return null;
+        }
+
+        const raw = Number(inputs.agedCareProbability);
+        if (!Number.isFinite(raw)) return null;
+
+        return Math.max(0, Math.min(1, raw > 1 ? raw / 100 : raw));
+    }
+
     // Calculate condition-based cost multipliers
     calculateConditionMultiplier(conditions, age) {
         let multiplier = 1.0;
@@ -437,12 +448,29 @@ export class HealthcareModelingEngine {
         // Residential care projection
         projections.residentialCare = this.calculateResidentialCareProjection(inputs, careProbs);
 
+        const userProbability = this.getUserAgedCareProbability(inputs);
+        if (userProbability !== null) {
+            const defaultOverall = Math.max(
+                projections.homeCare.probability || 0,
+                projections.residentialCare.probability || 0,
+            );
+
+            if (defaultOverall > 0) {
+                const scale = userProbability / defaultOverall;
+                projections.homeCare.probability = Math.max(0, Math.min(1, projections.homeCare.probability * scale));
+                projections.residentialCare.probability = Math.max(0, Math.min(1, projections.residentialCare.probability * scale));
+            } else {
+                projections.homeCare.probability = userProbability;
+                projections.residentialCare.probability = userProbability;
+            }
+        }
+
         // Calculate weighted expected costs
         const homeCareExpected = projections.homeCare.expectedCost * projections.homeCare.probability;
         const residentialExpected = projections.residentialCare.expectedCost * projections.residentialCare.probability;
 
         projections.totalExpectedCost = homeCareExpected + residentialExpected;
-        projections.probabilityOfNeed = Math.max(projections.homeCare.probability, projections.residentialCare.probability);
+        projections.probabilityOfNeed = userProbability ?? Math.max(projections.homeCare.probability, projections.residentialCare.probability);
 
         projections.recommendations = this.generateAgedCareRecommendations(projections, inputs);
 

--- a/src/js/recommendation.js
+++ b/src/js/recommendation.js
@@ -26,6 +26,9 @@ export const capRecommendationDelta = (rawDelta, baseMedian) => {
     return Math.max(-maxDelta, Math.min(maxDelta, rawDelta));
 };
 
+const resolveMonteCarloRuns = (inputs = {}) =>
+    Math.max(100, Math.min(20000, Math.round(Number(inputs.numRuns) || 1000)));
+
 class RecommendationEngine {
     constructor(simulator, inputs, config) {
         if (!simulator || !inputs || !config) {
@@ -76,8 +79,11 @@ class RecommendationEngine {
      */
     async runBaselineSimulation() {
         try {
-            // Use a reasonable number of runs for the baseline analysis
-            const baselineMC = await this.simulator.runMonteCarloSimulation(this.baseInputs, 1000, null);
+            const baselineMC = await this.simulator.runMonteCarloSimulation(
+                this.baseInputs,
+                resolveMonteCarloRuns(this.baseInputs),
+                null
+            );
             const baselineDeterministic = this.simulator.simulateRetirement(this.baseInputs, false);
 
             return {
@@ -460,7 +466,7 @@ class RecommendationEngine {
                     scenarios.push({
                         name: "Salary Sacrifice to Super (Cash Flow Optimized)",
                         description: `Based on your disposable income of $${Math.round(monthlyDisposableIncome)}/month, salary sacrifice $${additionalContrib.toLocaleString()} annually.`,
-                        modifications: { additionalSuperContributions: additionalContrib / totalIncome },
+                        modifications: this.buildSalarySacrificeModifications(additionalContrib),
                         feasibility: savingsCapacity.hasStrongCapacity ? "Easily Affordable" : "Manageable",
                         factorsChanged: [
                             `Monthly super increase: $${additionalMonthly} (within disposable income)`,
@@ -530,7 +536,7 @@ class RecommendationEngine {
                         description: `Transfer $${rebalanceAmount.toLocaleString()} from taxable investments to superannuation for tax efficiency.`,
                         modifications: {
                             currentStocks: this.baseInputs.currentStocks - rebalanceAmount,
-                            additionalSuperContributions: Math.min(rebalanceAmount / totalIncome, 0.1) // Cap at 10% of income
+                            yourAnnualNCC: rebalanceAmount
                         },
                         feasibility: "Tax Optimization Strategy",
                         factorsChanged: [
@@ -1258,9 +1264,7 @@ class RecommendationEngine {
             scenarios.push({
                 name: `Salary Sacrifice $${Math.round(additionalSuperAmount/1000)}k for Franking Credits in Super`,
                 description: `Salary sacrifice ${formatCurrency(additionalSuperAmount)} to super for franking credit benefits at 15% tax rate vs your ${marginalTaxRate}% marginal rate.`,
-                modifications: {
-                    additionalSuperContributions: additionalSuperAmount / (this.baseInputs.yourSalary + this.baseInputs.partnerSalary)
-                },
+                modifications: this.buildSalarySacrificeModifications(additionalSuperAmount),
                 feasibility: "Salary Packaging Required",
                 factorsChanged: [
                     `Additional super contribution: ${formatCurrency(additionalSuperAmount)}`,
@@ -1947,6 +1951,44 @@ class RecommendationEngine {
         return recommendations;
     }
 
+    buildSalarySacrificeModifications(additionalAnnualAmount) {
+        const employerRate = this.baseInputs.employerSuperContributionRate
+            ?? this.baseInputs.superContributionRate
+            ?? 0.12;
+        const concessionalCap = 30000;
+        let remaining = Math.max(0, Number(additionalAnnualAmount) || 0);
+        const modifications = {};
+
+        const candidates = [
+            {
+                salary: this.baseInputs.yourSalary || 0,
+                current: this.baseInputs.yourAdditionalSuperContribution || 0,
+                key: 'yourAdditionalSuperContribution',
+            },
+            {
+                salary: this.baseInputs.partnerSalary || 0,
+                current: this.baseInputs.partnerAdditionalSuperContribution || 0,
+                key: 'partnerAdditionalSuperContribution',
+            },
+        ]
+            .map((candidate) => ({
+                ...candidate,
+                room: Math.max(0, concessionalCap - (candidate.salary * employerRate) - candidate.current),
+            }))
+            .filter((candidate) => candidate.salary > 0 && candidate.room > 0)
+            .sort((left, right) => right.room - left.room);
+
+        for (const candidate of candidates) {
+            if (remaining <= 0) break;
+            const addition = Math.min(remaining, candidate.room);
+            if (addition <= 0) continue;
+            modifications[candidate.key] = candidate.current + addition;
+            remaining -= addition;
+        }
+
+        return modifications;
+    }
+
     /**
      * Creates a single recommendation object by categorizing and formatting the scenario result.
      * @param {Object} scenario - The scenario result object.
@@ -2056,7 +2098,10 @@ class RecommendationEngine {
 
     _formatContributionRecommendation(scenario, baseResult) {
         const successDiff = scenario.successRate - baseResult.successRate;
-        const balanceDiff = scenario.medianBalance - baseResult.medianBalance;
+        const balanceDiff = capRecommendationDelta(
+            scenario.medianBalance - baseResult.medianBalance,
+            baseResult.medianBalance
+        );
 
         let actionText = "";
         if (scenario.name.includes("by $500")) {
@@ -2070,7 +2115,10 @@ class RecommendationEngine {
 
     _formatAllocationRecommendation(scenario, baseResult) {
         const successDiff = scenario.successRate - baseResult.successRate;
-        const balanceDiff = scenario.medianBalance - baseResult.medianBalance;
+        const balanceDiff = capRecommendationDelta(
+            scenario.medianBalance - baseResult.medianBalance,
+            baseResult.medianBalance
+        );
 
         let tradeOffText = "";
         if (successDiff < 0 && balanceDiff > 0) {

--- a/src/js/recommendation.js
+++ b/src/js/recommendation.js
@@ -536,12 +536,12 @@ class RecommendationEngine {
                         description: `Transfer $${rebalanceAmount.toLocaleString()} from taxable investments to superannuation for tax efficiency.`,
                         modifications: {
                             currentStocks: this.baseInputs.currentStocks - rebalanceAmount,
-                            yourAnnualNCC: rebalanceAmount
+                            yourCurrentSuper: (this.baseInputs.yourCurrentSuper || 0) + rebalanceAmount
                         },
                         feasibility: "Tax Optimization Strategy",
                         factorsChanged: [
                             `Reduces taxable investment balance by $${rebalanceAmount.toLocaleString()}`,
-                            `Increases super contributions significantly`,
+                            `Moves $${rebalanceAmount.toLocaleString()} into super immediately`,
                             `Improves tax efficiency (super vs. taxable)`,
                             `No change to monthly cash flow requirements`,
                             `Better asset protection in super environment`

--- a/src/js/risk-profiling-engine.js
+++ b/src/js/risk-profiling-engine.js
@@ -142,7 +142,10 @@ export class RiskProfilingEngine {
         };
 
         // Risk tolerance questionnaire responses
-        const riskToleranceScore = inputs.riskTolerance || 50; // 0-100 scale
+        const rawRiskTolerance = Number(inputs.riskTolerance);
+        const riskToleranceScore = Number.isFinite(rawRiskTolerance)
+            ? Math.max(0, Math.min(100, rawRiskTolerance <= 10 ? rawRiskTolerance * 10 : rawRiskTolerance))
+            : 50;
 
         // Reaction to loss assessment
         tolerance.factors.reactionToLoss = this.assessReactionToLoss(inputs.lossReaction || 'concerned');

--- a/src/js/simulator.js
+++ b/src/js/simulator.js
@@ -33,6 +33,8 @@ import {
 } from './utils.js';
 
 const RUN_UNTIL_DEPLETION_AGE = 120;
+const resolveScenarioMonteCarloRuns = (inputs = {}) =>
+    Math.max(100, Math.min(20000, Math.round(Number(inputs.numRuns) || 1000)));
 
 export class RetirementSimulator {
     constructor(config) {
@@ -1103,7 +1105,7 @@ export class RetirementSimulator {
             effectiveYourLifespan - inputs.yourCurrentAge,
             effectivePartnerLifespan - inputs.partnerCurrentAge
         );
-        const yearsInRetirement = Math.max(0, maxYearsFromNow - yearsToRetirement);
+        const yearsInRetirement = Math.max(0, maxYearsFromNow - yearsToRetirement + 1);
 
         // Use scenario-adjusted inputs for all financial calculations
         inputs = effectiveInputs; // eslint-disable-line no-param-reassign
@@ -2403,7 +2405,11 @@ export class RetirementSimulator {
 
             // Run Monte Carlo simulation for this scenario
             // Note: Monte Carlo currently doesn't support stress scenarios, so it ignores them
-            const mcResult = await this.runMonteCarloSimulation(scenarioInputs, 1000, null);
+            const mcResult = await this.runMonteCarloSimulation(
+                scenarioInputs,
+                resolveScenarioMonteCarloRuns(scenarioInputs),
+                null
+            );
 
             // Run deterministic simulation for comparison with stress scenario
             const deterministicResult = this.simulateRetirement(scenarioInputs, false, stressScenario);

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -78,7 +78,8 @@ export const hasHighInterestDebt = (inputs = {}) => {
 /**
  * Resolve the Monte Carlo simulation run count for display in exports.
  *
- * Priority: monteCarloResults.runs → monteCarloResults.numRuns → inputs.numRuns → 1000.
+ * Priority: monteCarloResults.runs → monteCarloResults.totalRuns →
+ * monteCarloResults.numRuns → inputs.numRuns → 1000.
  *
  * Exported so tests can assert against this function directly rather than
  * reimplementing the priority logic (PR review comment #3247765338).
@@ -88,7 +89,7 @@ export const hasHighInterestDebt = (inputs = {}) => {
  * @returns {number}         – run count as a number (never a string)
  */
 export const resolveSimCount = (mcResults = {}, inputs = {}) =>
-    mcResults.runs ?? mcResults.numRuns ?? inputs.numRuns ?? 1000;
+    mcResults.runs ?? mcResults.totalRuns ?? mcResults.numRuns ?? inputs.numRuns ?? 1000;
 
 // Normalise a value that could be stored as either a decimal ratio (0–1) or
 // a percentage (1–100) into a decimal.  All internal calculations use decimals;
@@ -1556,7 +1557,7 @@ export const exportToXLSX = (inputs, results, chartManager, app = null) => {
 
     if (monteCarloResults) {
         summaryData.push(
-            ['Monte Carlo', 'Number of Simulations', monteCarloResults.runs || '1,000'],
+            ['Monte Carlo', 'Number of Simulations', resolveSimCount(monteCarloResults, inputs)],
             ['Monte Carlo', 'Success Rate', formatPercent(monteCarloResults.successRate)],
             ['Monte Carlo', 'Median Final Balance', formatCurrency(monteCarloResults.median)],
             ['Monte Carlo', '10th Percentile (Worst Case)', formatCurrency(monteCarloResults.percentile10 || 0)],

--- a/tests/unit/p2-p4-tasks.test.js
+++ b/tests/unit/p2-p4-tasks.test.js
@@ -533,6 +533,10 @@ describe('TASK-008 — resolveSimCount() from utils.js', () => {
         expect(resolveSimCount({ numRuns: 3000 })).toBe(3000);
     });
 
+    test('supports enhanced Monte Carlo results that expose totalRuns', () => {
+        expect(resolveSimCount({ totalRuns: 16000 })).toBe(16000);
+    });
+
     test('falls back to inputs.numRuns when both mc fields are absent', () => {
         expect(resolveSimCount({}, { numRuns: 16000 })).toBe(16000);
     });

--- a/tests/unit/report-regressions.test.js
+++ b/tests/unit/report-regressions.test.js
@@ -1,0 +1,82 @@
+import templateData from '../../src/retirement_template.json';
+import { ENHANCED_CONFIG } from '../../src/js/config.js';
+import RetirementSimulator from '../../src/js/simulator.js';
+import RecommendationEngine from '../../src/js/recommendation.js';
+import { RiskProfilingEngine } from '../../src/js/risk-profiling-engine.js';
+import { HealthcareModelingEngine } from '../../src/js/healthcare-modeling.js';
+
+describe('report regression fixes', () => {
+    test('healthcare modeling honours an explicit aged care probability from inputs', () => {
+        const engine = new HealthcareModelingEngine(ENHANCED_CONFIG);
+        const inputs = {
+            ...templateData.userData,
+            isSingleCalculation: false,
+            gender: 'male',
+            agedCareProbability: 0.22,
+        };
+
+        const agedCare = engine.calculateAgedCareProjections(inputs);
+        const summary = engine.generateHealthcareSummary(inputs);
+
+        expect(agedCare.probabilityOfNeed).toBeCloseTo(0.22, 6);
+        expect(summary.agedCareProbability).toBeCloseTo(0.22, 6);
+    });
+
+    test('risk tolerance on a 1-10 scale is normalised to the same score as 0-100 input', () => {
+        const engine = new RiskProfilingEngine(ENHANCED_CONFIG);
+
+        const fromTenPointScale = engine.assessRiskTolerance({ riskTolerance: 9 });
+        const fromHundredPointScale = engine.assessRiskTolerance({ riskTolerance: 90 });
+
+        expect(fromTenPointScale.score).toBeCloseTo(fromHundredPointScale.score, 6);
+        expect(fromTenPointScale.score).toBeGreaterThan(60);
+    });
+
+    test('deterministic projection runs until the older partner lifespan is reached', () => {
+        const simulator = new RetirementSimulator(ENHANCED_CONFIG);
+        const result = simulator.simulateRetirement(templateData.userData, false);
+        const finalYear = result.yearlyData.at(-1);
+
+        expect(finalYear.partnerAge).toBe(templateData.userData.partnerLifespan);
+        expect(finalYear.age).toBe(
+            templateData.userData.yourCurrentAge +
+            (templateData.userData.partnerLifespan - templateData.userData.partnerCurrentAge)
+        );
+    });
+
+    test('recommendation baseline Monte Carlo honours the requested run count', async () => {
+        const simulator = {
+            runMonteCarloSimulation: jest.fn().mockResolvedValue({ successRate: 0.9, median: 1_000_000 }),
+            simulateRetirement: jest.fn().mockReturnValue({ finalBalance: 900_000 }),
+        };
+        const engine = new RecommendationEngine(simulator, { numRuns: 16_000 }, ENHANCED_CONFIG);
+
+        await engine.runBaselineSimulation();
+
+        expect(simulator.runMonteCarloSimulation).toHaveBeenCalledWith(
+            { numRuns: 16_000 },
+            16_000,
+            null
+        );
+    });
+
+    test('salary sacrifice recommendation scenarios write to supported super contribution fields', () => {
+        const simulator = {
+            calculateCashFlowAnalysis: jest.fn().mockReturnValue({
+                cashFlow: { monthlyDisposableIncome: 1_000 },
+                savingsAnalysis: { canIncreaseSavings: true, hasStrongCapacity: true },
+            }),
+        };
+        const engine = new RecommendationEngine(simulator, templateData.userData, ENHANCED_CONFIG);
+
+        const modifications = engine.buildSalarySacrificeModifications(5_400);
+
+        expect(modifications.additionalSuperContributions).toBeUndefined();
+        const changedKey = Object.keys(modifications).find((key) =>
+            ['yourAdditionalSuperContribution', 'partnerAdditionalSuperContribution'].includes(key)
+        );
+
+        expect(changedKey).toBeDefined();
+        expect(modifications[changedKey]).toBeGreaterThan(templateData.userData[changedKey] || 0);
+    });
+});

--- a/tests/unit/report-regressions.test.js
+++ b/tests/unit/report-regressions.test.js
@@ -79,4 +79,32 @@ describe('report regression fixes', () => {
         expect(changedKey).toBeDefined();
         expect(modifications[changedKey]).toBeGreaterThan(templateData.userData[changedKey] || 0);
     });
+
+    test('rebalance investments to super is modeled as a one-off balance transfer', () => {
+        const simulator = {
+            calculateCashFlowAnalysis: jest.fn().mockReturnValue({
+                cashFlow: { monthlyDisposableIncome: 0 },
+                savingsAnalysis: { canIncreaseSavings: false, hasStrongCapacity: false },
+                opportunities: [],
+            }),
+        };
+        const inputs = {
+            ...templateData.userData,
+            currentStocks: 200_000,
+            yourCurrentSuper: 300_000,
+            hasInvestmentProperty: false,
+        };
+        const engine = new RecommendationEngine(simulator, inputs, ENHANCED_CONFIG);
+
+        const scenario = engine
+            ._analyzeContributions({})
+            .find(({ name }) => name === 'Rebalance Investments to Super');
+
+        expect(scenario).toBeDefined();
+        expect(scenario.modifications).toMatchObject({
+            currentStocks: 160_000,
+            yourCurrentSuper: 340_000,
+        });
+        expect(scenario.modifications.yourAnnualNCC).toBeUndefined();
+    });
 });


### PR DESCRIPTION
## Summary
- honour explicit aged-care probabilities in healthcare/export analysis and carry actual Monte Carlo run counts into report exports
- normalise 1-10 risk tolerance inputs correctly, extend couple projections through the older partner lifespan, and keep recommendation scenario Monte Carlo counts aligned with the requested runs
- wire salary-sacrifice recommendation scenarios to supported super contribution fields and add regression coverage for the reported report/model mismatches

## Testing
- npm test
- npm run build