### PR TITLE
Add missing advanced fields to advanced-v2.html

### DIFF
--- a/src/advanced-v2.html
+++ b/src/advanced-v2.html
@@ -602,7 +602,7 @@
                     <option value="directProperty">Direct Property in SMSF (liquidity risk)</option>
                   </select>
                 </div>
-                <div class="field-help">Strategy affects return expectations and liquidity risk</div>
+                <div class="field-help">Stored with your profile for reference and reporting</div>
               </div>
             </div>
           </div>
@@ -1116,7 +1116,16 @@
             </div>
             <div class="year-table-wrap">
               <table class="year-table">
-                <thead><tr><th>Year</th><th>Age</th><th>Super</th><th>Other liquid</th><th>Total assets</th><th>Withdraw</th><th>Age Pension</th><th>Income</th></tr></thead>
+                <thead><tr>
+                  <th title="Calendar year">Year</th>
+                  <th title="Your age at the start of the year. ★ marks retirement year.">Age</th>
+                  <th title="Superannuation account balance at year-end (accumulation + account-based pension phase combined).">Super</th>
+                  <th title="Non-super liquid assets: cash savings, shares, ETFs, term deposits and managed funds held outside super.">Other liquid</th>
+                  <th title="Super + other liquid + home equity + investment property equity. Non-liquid assets do not fund spending directly.">Total assets</th>
+                  <th title="Amount drawn from your portfolio to fund living expenses. Badge shows primary source: Super / Savings / Mixed. Overseas years show living cost + return-travel cost breakdown.">Withdraw</th>
+                  <th title="Government Age Pension income. Subject to assets test and income test. AWLR-proportional if living overseas.">Age Pension</th>
+                  <th title="Total retirement income: portfolio withdrawals + Age Pension + investment property income + other income sources.">Income</th>
+                </tr></thead>
                 <tbody id="year-tbody"></tbody>
               </table>
             </div>

--- a/src/advanced-v2.html
+++ b/src/advanced-v2.html
@@ -465,15 +465,37 @@
           </div>
 
           <div class="subhead">Family carer</div>
-          <div class="fields three">
+          <div class="fields">
             <label class="toggle"><input id="isCarer" type="checkbox" /><span class="track"></span><span class="label">I am a carer for aged parents / family</span></label>
-            <div class="field">
-              <label class="field-label" for="carerReducedWorkPercent"><span>Work reduction</span><span class="hint">%</span></label>
-              <div class="field-input"><input id="carerReducedWorkPercent" type="number" step="1" value="0" /><span class="suffix">%</span></div>
-            </div>
-            <div class="field">
-              <label class="field-label" for="carerYearsExpected"><span>Expected carer years</span></label>
-              <div class="field-input"><input id="carerYearsExpected" type="number" value="0" /><span class="suffix">yrs</span></div>
+          </div>
+          <div data-carer="true" hidden>
+            <div class="fields three">
+              <div class="field">
+                <label class="field-label" for="carerReducedWorkPercent"><span>Work reduction due to caring</span><span class="hint">%</span></label>
+                <div class="field-input"><input id="carerReducedWorkPercent" type="number" step="1" value="0" /><span class="suffix">%</span></div>
+                <div class="field-help">Estimated % reduction in income/work capacity while caring</div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="carerYearsExpected"><span>Expected years of caring</span></label>
+                <div class="field-input"><input id="carerYearsExpected" type="number" value="0" /><span class="suffix">yrs</span></div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="agedParentsLocation"><span>Aged parents location</span></label>
+                <div class="field-input">
+                  <select id="agedParentsLocation">
+                    <option value="australia">In Australia (citizens / residents)</option>
+                    <option value="australia-non-citizen">In Australia (non-citizens / temp visa)</option>
+                    <option value="overseas">Overseas (no AU Age Pension)</option>
+                    <option value="mixed">Mixed (some AU, some overseas)</option>
+                  </select>
+                </div>
+                <div class="field-help">Non-citizen parents overseas do not receive the Australian Age Pension</div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="carerAnnualExpense"><span>Annual financial support to parents / family</span><span class="hint">$/year</span></label>
+                <div class="field-input has-prefix"><span class="prefix">$</span><input id="carerAnnualExpense" type="number" value="0" /><span class="suffix">/yr</span></div>
+                <div class="field-help">Funds sent or spent supporting parents — reduces your savings capacity</div>
+              </div>
             </div>
           </div>
         </div>
@@ -554,11 +576,105 @@
           <svg class="section-chev" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
         </button>
         <div class="section-body">
+
+          <!-- ── SMSF ── -->
+          <div class="subhead">Self-Managed Super Fund (SMSF)</div>
+          <div class="notice"><span class="ic">⚠️</span><div><b>SMSF regulatory note:</b> ASIC recommends a balance of at least $200k–$500k to justify ongoing costs. Balances below $300k may result in higher fees as a proportion of assets. <a href="smsf-guide.html">Read the SMSF guide →</a></div></div>
           <div class="fields">
-            <label class="toggle"><input id="hasSmsf" type="checkbox" /><span class="track"></span><span class="label">I have a Self-Managed Super Fund</span></label>
+            <label class="toggle"><input id="hasSmsf" type="checkbox" /><span class="track"></span><span class="label">I have a Self-Managed Super Fund (SMSF)</span></label>
+          </div>
+          <div data-smsf="true" hidden>
+            <div id="smsfLowBalanceWarning" class="notice" hidden><span class="ic">⚠️</span><div>SMSF balance below $300,000 — admin costs may represent a disproportionate share. Consider consolidating into a retail or industry super fund.</div></div>
+            <div class="fields">
+              <div class="field">
+                <label class="field-label" for="smsfAdminCosts"><span>Annual SMSF admin &amp; compliance costs</span><span class="hint">$/year</span></label>
+                <div class="field-input has-prefix"><span class="prefix">$</span><input id="smsfAdminCosts" type="number" value="3500" /></div>
+                <div class="field-help">Audit, accounting, ASIC fees, and admin (typically $3,000–$6,000/yr)</div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="smsfInvestmentStrategy"><span>SMSF investment strategy</span></label>
+                <div class="field-input">
+                  <select id="smsfInvestmentStrategy">
+                    <option value="balanced">Balanced (60% equities, 40% other)</option>
+                    <option value="growth">Growth (80% equities, 20% other)</option>
+                    <option value="highGrowth">High Growth (90%+ equities)</option>
+                    <option value="conservative">Conservative (40% equities, 60% other)</option>
+                    <option value="directProperty">Direct Property in SMSF (liquidity risk)</option>
+                  </select>
+                </div>
+                <div class="field-help">Strategy affects return expectations and liquidity risk</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- ── TRUST ── -->
+          <div class="subhead" style="margin-top:18px">Trust assets &amp; control</div>
+          <div class="notice"><span class="ic">ℹ️</span><div>Trust assets may be attributed to you for Age Pension means testing if you have control. Consult a financial adviser. <a href="trust-company-structure.html">Trusts &amp; companies guide →</a></div></div>
+          <div class="fields">
             <label class="toggle"><input id="hasTrust" type="checkbox" /><span class="track"></span><span class="label">I have trust assets or control</span></label>
           </div>
-          <div class="notice"><span class="ic">ℹ️</span><div>See <a href="smsf-guide.html">SMSF guide</a> · <a href="trust-company-structure.html">Trusts &amp; companies guide</a></div></div>
+          <div data-trust="true" hidden>
+            <div class="fields three">
+              <div class="field">
+                <label class="field-label" for="trustType"><span>Primary trust type</span></label>
+                <div class="field-input">
+                  <select id="trustType">
+                    <option value="discretionary">Discretionary Family Trust</option>
+                    <option value="unit">Unit Trust</option>
+                    <option value="hybrid">Hybrid Trust</option>
+                    <option value="other">Other Trust Structure</option>
+                  </select>
+                </div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="trustControlLevel"><span>Control level</span></label>
+                <div class="field-input">
+                  <select id="trustControlLevel">
+                    <option value="high">High Control (Trustee / Appointer / Beneficiary)</option>
+                    <option value="medium">Medium Control (Beneficiary with influence)</option>
+                    <option value="low">Low Control (Beneficiary only)</option>
+                    <option value="none">No Control (Arms-length)</option>
+                  </select>
+                </div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="trustNetAssets"><span>Current trust net assets</span><span class="hint">$</span></label>
+                <div class="field-input has-prefix"><span class="prefix">$</span><input id="trustNetAssets" type="number" value="0" /></div>
+                <div class="field-help">Total trust assets minus liabilities</div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="trustAttributionPercentage"><span>Centrelink attribution</span><span class="hint">%</span></label>
+                <div class="field-input"><input id="trustAttributionPercentage" type="number" step="1" value="100" min="0" max="100" /><span class="suffix">%</span></div>
+                <div class="field-help">% of trust assets attributed to you (100% = high control)</div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="trustAnnualDistributions"><span>Annual distributions received</span><span class="hint">$</span></label>
+                <div class="field-input has-prefix"><span class="prefix">$</span><input id="trustAnnualDistributions" type="number" value="0" /></div>
+                <div class="field-help">Actual distributions received in last financial year</div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="trustTaxRate"><span>Trust tax rate</span><span class="hint">%</span></label>
+                <div class="field-input"><input id="trustTaxRate" type="number" step="1" value="30" min="0" max="47" /><span class="suffix">%</span></div>
+                <div class="field-help">Effective rate on undistributed income (typically 30–47%)</div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="familyTrustIncomeDistribution"><span>Annual income distributed from trust</span><span class="hint">$</span></label>
+                <div class="field-input has-prefix"><span class="prefix">$</span><input id="familyTrustIncomeDistribution" type="number" value="0" /></div>
+                <div class="field-help">Total distributions to all beneficiaries (income test)</div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="beneficiaryAllocation"><span>Your share of distributions</span><span class="hint">%</span></label>
+                <div class="field-input"><input id="beneficiaryAllocation" type="number" step="1" value="100" min="0" max="100" /><span class="suffix">%</span></div>
+                <div class="field-help">% of trust distributions allocated to you (income test)</div>
+              </div>
+            </div>
+            <div class="fields">
+              <label class="toggle"><input id="homeInTrust" type="checkbox" /><span class="track"></span><span class="label">Principal residence held in trust (may lose Age Pension home exemption)</span></label>
+              <label class="toggle"><input id="investmentPropertyInTrust" type="checkbox" /><span class="track"></span><span class="label">Investment property held in trust</span></label>
+              <label class="toggle"><input id="stocksInTrust" type="checkbox" /><span class="track"></span><span class="label">Share portfolio held in trust</span></label>
+            </div>
+          </div>
+
         </div>
       </section>
 
@@ -722,22 +838,239 @@
             <label class="toggle"><input id="goingOverseas" type="checkbox" /><span class="track"></span><span class="label">I plan to retire (partly or fully) overseas</span></label>
           </div>
           <div data-overseas="true" hidden>
+
+            <!-- Status banner -->
+            <div class="notice" id="overseasBanner"><span class="ic">🌍</span><div>
+              <b>Overseas retirement analysis</b> — age pension portability, tax residency, and FX impact will be assessed when you run the simulation.
+            </div></div>
+
+            <!-- ── Residence plans ── -->
+            <div class="subhead">Residence plans</div>
+            <div class="fields">
+              <div class="field">
+                <label class="field-label" for="destination"><span>Retirement destination</span></label>
+                <div class="field-input">
+                  <select id="destination">
+                    <option value="">Select country…</option>
+                    <optgroup label="Social Security Agreement countries">
+                      <option value="portugal">Portugal 🇵🇹 (SSA + NHR tax scheme)</option>
+                      <option value="spain">Spain 🇪🇸 (SSA)</option>
+                      <option value="italy">Italy 🇮🇹 (SSA + 7% flat tax regions)</option>
+                      <option value="canada">Canada 🇨🇦 (SSA)</option>
+                      <option value="newzealand">New Zealand 🇳🇿 (SSA + easy visa)</option>
+                      <option value="japan">Japan 🇯🇵 (SSA + world-class healthcare)</option>
+                      <option value="india">India 🇮🇳 (SSA + ultra-low cost)</option>
+                      <option value="usa">United States 🇺🇸 (SSA — high cost, hard visa)</option>
+                    </optgroup>
+                    <optgroup label="Popular destinations (no SSA)">
+                      <option value="thailand">Thailand 🇹🇭 (very affordable, LTR visa)</option>
+                      <option value="vietnam">Vietnam 🇻🇳 (lowest cost, DTA, e-visa)</option>
+                      <option value="malaysia">Malaysia 🇲🇾 (MM2H visa, English)</option>
+                      <option value="bali">Bali, Indonesia 🇮🇩 (closest, low cost)</option>
+                      <option value="philippines">Philippines 🇵🇭 (SRRV visa, English)</option>
+                    </optgroup>
+                    <optgroup label="Other">
+                      <option value="other">Other country</option>
+                    </optgroup>
+                  </select>
+                </div>
+              </div>
+            </div>
             <div class="fields three">
               <div class="field">
-                <label class="field-label" for="destination"><span>Destination</span></label>
-                <div class="field-input"><select id="destination">
-                  <option value="">Select country…</option>
-                  <option value="portugal">Portugal 🇵🇹 (SSA)</option>
-                  <option value="nz">New Zealand 🇳🇿 (SSA)</option>
-                  <option value="thailand">Thailand 🇹🇭</option>
-                  <option value="vietnam">Vietnam 🇻🇳</option>
-                  <option value="malaysia">Malaysia 🇲🇾</option>
-                  <option value="other">Other</option>
-                </select></div>
+                <label class="field-label" for="australianResidenceYears"><span>Years lived in Australia</span><span class="hint">for AWLR</span></label>
+                <div class="field-input"><input id="australianResidenceYears" type="number" value="" min="0" max="51" /><span class="suffix">yrs</span></div>
+                <div class="field-help">Between ages 16–67. Leave blank to auto-calculate from your current age.</div>
               </div>
-              <div class="field"><label class="field-label" for="ageMovingOverseas"><span>Age moving overseas</span></label><div class="field-input"><input id="ageMovingOverseas" type="number" value="0" /><span class="suffix">yrs</span></div></div>
-              <div class="field"><label class="field-label" for="annualLivingCostOverseas"><span>Annual living cost</span><span class="hint">AUD/yr</span></label><div class="field-input has-prefix"><span class="prefix">$</span><input id="annualLivingCostOverseas" type="number" value="40000" /></div></div>
+              <div class="field">
+                <label class="field-label" for="ageMovingOverseas"><span>Age moving overseas</span></label>
+                <div class="field-input"><input id="ageMovingOverseas" type="number" value="65" min="55" max="90" /><span class="suffix">yrs</span></div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="annualLivingCostOverseas"><span>Annual living cost overseas</span><span class="hint">AUD/yr</span></label>
+                <div class="field-input has-prefix"><span class="prefix">$</span><input id="annualLivingCostOverseas" type="number" value="40000" /></div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="returnFrequency"><span>Return to Australia frequency</span></label>
+                <div class="field-input">
+                  <select id="returnFrequency">
+                    <option value="never">Never (permanent move)</option>
+                    <option value="annually">Once per year (3–4 weeks)</option>
+                    <option value="biannually">Twice per year (6–8 weeks total)</option>
+                    <option value="quarterly">Every 3 months (3–4 months/yr)</option>
+                    <option value="seasonal">6 months each (seasonal)</option>
+                  </select>
+                </div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="overseasMoveType"><span>Type of move</span></label>
+                <div class="field-input">
+                  <select id="overseasMoveType">
+                    <option value="permanent">Permanent move (living overseas)</option>
+                    <option value="extended_temporary">Extended stay &gt;26 weeks (planning to return)</option>
+                    <option value="long_absence">Holiday / visit 6–26 weeks</option>
+                    <option value="short_absence">Short trip ≤6 weeks</option>
+                  </select>
+                </div>
+                <div class="field-help">For a permanent move, Pension Supplement stops from the departure date — not after 26 weeks</div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="overseasTaxResidency"><span>Tax residency assumption</span></label>
+                <div class="field-input">
+                  <select id="overseasTaxResidency">
+                    <option value="australian">Remain Australian tax resident</option>
+                    <option value="foreign">Become foreign tax resident</option>
+                    <option value="uncertain">Uncertain — seek advice</option>
+                  </select>
+                </div>
+                <div class="field-help">Foreign residents lose the tax-free threshold; 30% flat rate on AU-sourced income</div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="overseasHealthCover"><span>Overseas health cover plan</span></label>
+                <div class="field-input">
+                  <select id="overseasHealthCover">
+                    <option value="international_private">International private health insurance</option>
+                    <option value="local_public">Local public healthcare system</option>
+                    <option value="local_private">Local private insurance</option>
+                    <option value="none">No cover arranged yet</option>
+                  </select>
+                </div>
+                <div class="field-help">Medicare does not cover overseas treatment. Pensioner Concession Card cancelled after 6 weeks abroad.</div>
+              </div>
             </div>
+            <div class="fields">
+              <label class="toggle"><input id="overseasAgreementCountry" type="checkbox" /><span class="track"></span><span class="label">Destination has Social Security Agreement with Australia (avoids 2-year former-resident waiting period)</span></label>
+              <label class="toggle"><input id="maintainResidency" type="checkbox" /><span class="track"></span><span class="label">Maintain Australian tax residency (complex — seek specialist advice)</span></label>
+            </div>
+
+            <!-- ── Asset structure ── -->
+            <div class="subhead">Asset structure strategy</div>
+            <div class="fields three">
+              <div class="field">
+                <label class="field-label" for="propertyStrategy"><span>Property strategy</span></label>
+                <div class="field-input">
+                  <select id="propertyStrategy">
+                    <option value="keep-personal">Keep in personal names</option>
+                    <option value="transfer-trust">Transfer to Family Trust</option>
+                    <option value="sell-before">Sell before departure</option>
+                    <option value="sell-after">Sell after establishing overseas residency</option>
+                  </select>
+                </div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="trustBeneficiaries"><span>Trust beneficiaries (if using trust)</span></label>
+                <div class="field-input">
+                  <select id="trustBeneficiaries">
+                    <option value="you-only">Yourself only</option>
+                    <option value="you-partner">You and partner</option>
+                    <option value="family">Extended family</option>
+                    <option value="australian-residents">Australian resident children</option>
+                  </select>
+                </div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="superAccess"><span>Superannuation access strategy</span></label>
+                <div class="field-input">
+                  <select id="superAccess">
+                    <option value="pension-mode">Pension mode (regular payments)</option>
+                    <option value="partial-lump">Partial lump sum before departure</option>
+                    <option value="full-lump">Full lump sum before departure</option>
+                    <option value="mixed">Mixed strategy</option>
+                  </select>
+                </div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="estimatedLivingCosts"><span>Estimated annual living costs overseas</span><span class="hint">AUD/yr</span></label>
+                <div class="field-input has-prefix"><span class="prefix">$</span><input id="estimatedLivingCosts" type="number" value="60000" step="1000" /></div>
+                <div class="field-help">In Australian dollars — include healthcare, housing, and lifestyle</div>
+              </div>
+            </div>
+
+            <!-- ── Currency & housing ── -->
+            <div class="subhead">Currency &amp; housing</div>
+            <div class="fields three">
+              <div class="field">
+                <label class="field-label" for="overseasSpendingCurrency"><span>Spending currency</span></label>
+                <div class="field-input">
+                  <select id="overseasSpendingCurrency">
+                    <option value="AUD">AUD (Australian Dollar)</option>
+                    <option value="EUR">EUR (Euro)</option>
+                    <option value="GBP">GBP (British Pound)</option>
+                    <option value="USD">USD (US Dollar)</option>
+                    <option value="NZD">NZD (New Zealand Dollar)</option>
+                    <option value="SGD">SGD (Singapore Dollar)</option>
+                    <option value="THB">THB (Thai Baht)</option>
+                    <option value="IDR">IDR (Indonesian Rupiah)</option>
+                    <option value="other">Other</option>
+                  </select>
+                </div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="overseasAudFxChange"><span>Annual AUD FX change vs local</span><span class="hint">%/yr</span></label>
+                <div class="field-input"><input id="overseasAudFxChange" type="number" step="0.5" value="-1" min="-10" max="10" /><span class="suffix">%</span></div>
+                <div class="field-help">Negative = AUD depreciates (your costs rise). Positive = AUD strengthens.</div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="overseasHousingType"><span>Local housing arrangement</span></label>
+                <div class="field-input">
+                  <select id="overseasHousingType">
+                    <option value="rent">Renting</option>
+                    <option value="own">Own local property</option>
+                    <option value="family">Living with family</option>
+                    <option value="nomadic">Nomadic / short-term stays</option>
+                  </select>
+                </div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="overseasAnnualRent"><span>Annual rent (AUD equivalent)</span><span class="hint">if renting</span></label>
+                <div class="field-input has-prefix"><span class="prefix">$</span><input id="overseasAnnualRent" type="number" value="18000" step="500" /></div>
+                <div class="field-help">Annual rent converted to AUD at current rates. Subject to FX drift.</div>
+              </div>
+            </div>
+
+            <!-- ── Return-to-Australia fallback ── -->
+            <div class="subhead">Return-to-Australia fallback</div>
+            <div class="fields">
+              <div class="field">
+                <label class="field-label" for="overseasFallbackAge"><span>Age of return</span><span class="hint">0 = no planned return</span></label>
+                <div class="field-input"><input id="overseasFallbackAge" type="number" value="0" min="0" max="110" step="1" /><span class="suffix">yrs</span></div>
+                <div class="field-help">Pension portability and AWLR rules reset on return</div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="overseasFallbackTrigger"><span>Likely return trigger</span></label>
+                <div class="field-input">
+                  <select id="overseasFallbackTrigger">
+                    <option value="none">No planned return</option>
+                    <option value="health">Health / aged care needs</option>
+                    <option value="financial">Financial difficulty</option>
+                    <option value="social">Social / family reasons</option>
+                    <option value="partner_death">After partner death</option>
+                    <option value="elective">Elective lifestyle choice</option>
+                  </select>
+                </div>
+              </div>
+            </div>
+
+            <!-- ── Scenario results container (populated by JS) ── -->
+            <div class="notice" style="margin-top:14px"><span class="ic">📊</span><div>
+              Run the simulation to see the <b>four-scenario Age Pension comparison</b> (stay in AU vs permanent move vs extended stay vs seasonal) in the Summary tab.
+            </div></div>
+
+            <!-- ── Key rules ── -->
+            <details style="margin-top:14px">
+              <summary style="cursor:pointer;font-size:13px;font-weight:600;color:var(--ink-2);padding:8px 0">⚠️ Key overseas retirement rules (March 2026)</summary>
+              <div style="font-size:12.5px;color:var(--ink-2);line-height:1.7;margin-top:8px;padding:12px;background:var(--surface-2,#f9f9f9);border-radius:10px">
+                <p>• <b>6-week rule:</b> After 6 weeks continuously overseas the Pension Supplement drops to basic rate only and Energy Supplement stops. Pensioner Concession Card is cancelled. Base pension rate is unchanged.</p>
+                <p>• <b>26-week rule:</b> After 26 weeks, an AWLR-proportional rate applies if your Australian Working Life Residence is below 35 years. 35+ years = full rate continues.</p>
+                <p>• <b>Permanent move:</b> Pension Supplement top-up and Energy Supplement stop from the <em>departure date</em> — not after 6 weeks. Critical distinction.</p>
+                <p>• <b>Principal home — asset test:</b> The home is fully exempt. If you sell and rent, you become a non-homeowner; higher thresholds apply but sale proceeds are assessable for 24 months unless reinvested.</p>
+                <p>• <b>Return to AU:</b> Leaving again within 2 years of returning and starting Age Pension may stop payments (exceptions: SSA countries, humanitarian visas).</p>
+                <p>• <b>Healthcare:</b> Medicare does not cover overseas treatment. Private international health insurance strongly recommended.</p>
+                <p>• <b>Super:</b> Access rules (age 60+) apply regardless of residency. Some funds close accounts for permanent overseas residents — check with your fund.</p>
+                <p>• <b>Tax:</b> Foreign residents lose the tax-free threshold and pay 30% on AU-sourced income from the first dollar. Double Tax Agreements may reduce this for SSA countries.</p>
+              </div>
+            </details>
+
           </div>
         </div>
       </section>

--- a/src/advanced.html
+++ b/src/advanced.html
@@ -828,6 +828,13 @@
             border-top: 2px solid var(--color-gold-500);
             border-bottom: 2px solid var(--color-gold-500);
         }
+        .data-table tbody tr.overseas-row td:first-child { color: #0d9488; font-weight: 700; }
+        .data-table tbody tr.overseas-row { background: #f0fdfa; }
+        .wy-src { display:inline-block;font-size:10px;padding:1px 5px;border-radius:3px;margin-left:4px;vertical-align:middle;font-weight:600; }
+        .wy-src.src-super { background:#ede9fe;color:#5b21b6; }
+        .wy-src.src-savings { background:#dcfce7;color:#15803d; }
+        .wy-src.src-mixed { background:#fef3c7;color:#b45309; }
+        .wy-src.src-depleted { background:#fee2e2;color:#b91c1c; }
         .data-table tbody td {
             padding: 0.5rem 0.75rem;
             color: var(--color-charcoal-700);
@@ -3186,7 +3193,7 @@
                                 <option value="conservative">Conservative (40% equities, 60% other)</option>
                                 <option value="directProperty">Direct Property in SMSF (liquidity risk)</option>
                             </select>
-                            <p class="mt-1 text-xs text-gray-500">Strategy affects return expectations and liquidity risk</p>
+                            <p class="mt-1 text-xs text-gray-500">Stored with your profile for reference and reporting</p>
                         </div>
                     </div>
                 </div>
@@ -4716,44 +4723,51 @@
                 <p><strong>Note:</strong> This projection includes healthcare costs, aged care planning, and investment
                     property modeling.</p>
             </div>
+            <div id="careerImpactBanner"></div>
             <div class="overflow-x-auto">
                 <table class="min-w-full divide-y divide-gray-200 data-table">
                     <thead class="bg-gray-50">
                     <tr>
-                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-help"
+                            title="Calendar year. ★ marks the retirement year. ✈ marks years spent overseas.">
                             Year
                         </th>
-                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Age
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-help"
+                            title="Your age (and partner age if applicable) at the start of the year.">Age
                         </th>
                         <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-help"
-                            title="Super, savings, stocks, and accessible home equity - can be spent during retirement">
+                            title="Super, savings, shares and accessible home equity — assets that can be drawn down during retirement without selling property.">
                             Liquid Assets 💳
                         </th>
                         <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-help"
-                            title="Home equity and investment property - requires selling/downsizing to access">
+                            title="Home equity and investment property equity — requires selling or downsizing to access. Not counted in drawdown calculations.">
                             Non-Liquid Assets 🏘️
                         </th>
-                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-help"
+                            title="Investment growth on liquid assets during the year (return rate × beginning balance). Does not include property capital growth.">
                             Growth
                         </th>
-                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-help"
+                            title="Annual amount drawn from your portfolio to fund living expenses. Badge shows primary funding source: Super / Savings / Mixed. Overseas years show living cost + return-travel cost.">
                             Yearly Withdrawal
                         </th>
-                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-help"
+                            title="Net cash flow from investment property: rental income minus loan interest, expenses, and land tax. Can be negative (negative gearing).">
                             Property Income
                         </th>
-                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-help"
+                            title="Annual healthcare costs, growing at the healthcare inflation rate (typically 5–6% p.a. per AIHW long-run data), which is faster than general CPI.">
                             Healthcare
                         </th>
-                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Aged
-                            Care
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-help"
+                            title="Aged care costs when applicable (65% probability per AIHW). Modelled as a lump-sum event starting at the age you specify. Average cost ~$75,000/year.">
+                            Aged Care
                         </th>
                         <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-help"
-                            title="Liquid assets available for spending after all transactions">End Balance 💰
+                            title="Liquid assets remaining at year-end after growth, withdrawal, property income, healthcare and aged care costs.">End Balance 💰
                         </th>
                         <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-help"
-                            title="Total net worth including property equity (liquid + non-liquid assets)">Total Net
-                            Worth 🏠
+                            title="Total net worth: liquid assets + home equity + investment property equity. Property is shown at estimated market value less outstanding loan.">Total Net Worth 🏠
                         </th>
                     </tr>
                     </thead>

--- a/src/css/redesign.css
+++ b/src/css/redesign.css
@@ -913,6 +913,14 @@ table.year-table tr.retire td { background: color-mix(in oklab, var(--accent) 8%
 table.year-table tr.retire td:first-child { background: color-mix(in oklab, var(--accent) 12%, var(--surface)); }
 table.year-table tr.pension td:first-child { color: var(--accent-ink); }
 table.year-table tr.depleted td { color: var(--rose); }
+table.year-table tr.overseas td:first-child { color: var(--teal, #0d9488); }
+table.year-table tr.overseas td { background: color-mix(in oklab, var(--teal, #0d9488) 4%, var(--surface)); }
+.wy-src { display: inline-block; font-size: 10px; padding: 1px 5px; border-radius: 3px; margin-left: 4px; vertical-align: middle; font-weight: 600; letter-spacing: 0.02em; }
+.wy-src.src-super { background: color-mix(in oklab, var(--accent) 15%, var(--surface-2)); color: var(--accent-ink); }
+.wy-src.src-savings { background: color-mix(in oklab, #16a34a 15%, var(--surface-2)); color: #15803d; }
+.wy-src.src-mixed { background: color-mix(in oklab, #d97706 12%, var(--surface-2)); color: #b45309; }
+.wy-src.src-depleted { background: color-mix(in oklab, var(--rose) 15%, var(--surface-2)); color: var(--rose); }
+table.year-table th[title] { cursor: help; border-bottom: 1px dotted var(--border); }
 
 /* ============================================================
    Floating action bar (mobile + tools)

--- a/src/js/advanced-v2.js
+++ b/src/js/advanced-v2.js
@@ -286,17 +286,17 @@ function buildEngineInputs(inp) {
     allocCash: pct(DEFAULTS.allocation.allocCash, DEFAULTS.allocation.allocCash),
 
     hasTrustAssets: inp.hasTrust,
-    trustType: DEFAULTS.trust.trustType,
-    trustControlLevel: DEFAULTS.trust.trustControlLevel,
-    trustNetAssets: 0,
-    trustAttributionPercentage: 1,
-    trustAnnualDistributions: 0,
-    trustTaxRate: 0.3,
-    familyTrustIncomeDistribution: 0,
-    beneficiaryAllocation: 1,
-    homeInTrust: false,
-    investmentPropertyInTrust: false,
-    stocksInTrust: false,
+    trustType: inp.trustType || DEFAULTS.trust.trustType,
+    trustControlLevel: inp.trustControlLevel || DEFAULTS.trust.trustControlLevel,
+    trustNetAssets: inp.trustNetAssets || 0,
+    trustAttributionPercentage: pct(inp.trustAttributionPercentage ?? 100, 100),
+    trustAnnualDistributions: inp.trustAnnualDistributions || 0,
+    trustTaxRate: pct(inp.trustTaxRate ?? 30, 30),
+    familyTrustIncomeDistribution: inp.familyTrustIncomeDistribution || 0,
+    beneficiaryAllocation: pct(inp.beneficiaryAllocation ?? 100, 100),
+    homeInTrust: inp.homeInTrust || false,
+    investmentPropertyInTrust: inp.investmentPropertyInTrust || false,
+    stocksInTrust: inp.stocksInTrust || false,
 
     returnVolatility: pct(inp.returnVolatility || DEFAULTS.simulation.returnVolatility, DEFAULTS.simulation.returnVolatility),
     enableShocks: inp.enableShocks,
@@ -325,7 +325,8 @@ function buildEngineInputs(inp) {
     isCarerForParents: inp.isCarer,
     carerReducedWorkPercent: inp.isCarer ? pct(inp.carerReducedWorkPercent) : 0,
     carerYearsExpected: inp.isCarer ? inp.carerYearsExpected : 0,
-    carerAnnualExpense: inp.annualParentSupport,
+    agedParentsLocation: inp.agedParentsLocation || 'australia',
+    carerAnnualExpense: inp.isCarer ? (inp.carerAnnualExpense || inp.annualParentSupport || 0) : 0,
     privateSchool: inp.privateSchool,
     universitySupport: inp.uniSupport,
     educationCostPerChild: inp.educationCostPerChild,
@@ -337,7 +338,8 @@ function buildEngineInputs(inp) {
     spouseContribution: inp.spouseContribution,
     downsizeContribution: inp.useDownsizer,
     hasSMSF: inp.hasSmsf,
-    smsfAdminCosts: 3500,
+    smsfAdminCosts: inp.smsfAdminCosts || 3500,
+    smsfInvestmentStrategy: inp.smsfInvestmentStrategy || 'balanced',
     annualTravelBudget: 0,
     annualHobbyBudget: 0,
     legacyGoal: 0,
@@ -675,6 +677,8 @@ function readInputs() {
     annualParentSupport: num('annualParentSupport'),
     carerReducedWorkPercent: num('carerReducedWorkPercent'),
     carerYearsExpected: num('carerYearsExpected'),
+    agedParentsLocation: val('agedParentsLocation', 'australia'),
+    carerAnnualExpense: num('carerAnnualExpense'),
 
     // Property & debt
     homeValue: num('homeValue'),
@@ -700,7 +704,20 @@ function readInputs() {
 
     // SMSF & Trust
     hasSmsf: chk('hasSmsf'),
+    smsfAdminCosts: num('smsfAdminCosts', 3500),
+    smsfInvestmentStrategy: val('smsfInvestmentStrategy', 'balanced'),
     hasTrust: chk('hasTrust'),
+    trustType: val('trustType', 'discretionary'),
+    trustControlLevel: val('trustControlLevel', 'high'),
+    trustNetAssets: num('trustNetAssets'),
+    trustAttributionPercentage: num('trustAttributionPercentage', 100),
+    trustAnnualDistributions: num('trustAnnualDistributions'),
+    homeInTrust: chk('homeInTrust'),
+    investmentPropertyInTrust: chk('investmentPropertyInTrust'),
+    stocksInTrust: chk('stocksInTrust'),
+    trustTaxRate: num('trustTaxRate', 30),
+    familyTrustIncomeDistribution: num('familyTrustIncomeDistribution'),
+    beneficiaryAllocation: num('beneficiaryAllocation', 100),
 
     // Goal
     desiredIncome: num('desiredIncome', 73000),
@@ -738,8 +755,25 @@ function readInputs() {
     // Overseas
     goingOverseas: chk('goingOverseas'),
     destination: val('destination'),
+    australianResidenceYears: num('australianResidenceYears'),
     ageMovingOverseas: num('ageMovingOverseas'),
     annualLivingCostOverseas: num('annualLivingCostOverseas', 40000),
+    returnFrequency: val('returnFrequency', 'never'),
+    overseasMoveType: val('overseasMoveType', 'permanent'),
+    overseasAgreementCountry: chk('overseasAgreementCountry'),
+    overseasTaxResidency: val('overseasTaxResidency', 'australian'),
+    overseasHealthCover: val('overseasHealthCover', 'international_private'),
+    maintainResidency: chk('maintainResidency'),
+    propertyStrategy: val('propertyStrategy', 'keep-personal'),
+    trustBeneficiaries: val('trustBeneficiaries', 'you-only'),
+    superAccess: val('superAccess', 'pension-mode'),
+    estimatedLivingCosts: num('estimatedLivingCosts', 60000),
+    overseasSpendingCurrency: val('overseasSpendingCurrency', 'AUD'),
+    overseasAudFxChange: num('overseasAudFxChange', -1),
+    overseasHousingType: val('overseasHousingType', 'rent'),
+    overseasAnnualRent: num('overseasAnnualRent', 18000),
+    overseasFallbackAge: num('overseasFallbackAge'),
+    overseasFallbackTrigger: val('overseasFallbackTrigger', 'none'),
   };
 }
 
@@ -2286,6 +2320,9 @@ function boot() {
     initPensionFieldDefaults();
     bindConditional('investmentProperty', 'data-ip');
     bindConditional('goingOverseas', 'data-overseas');
+    bindConditional('isCarer', 'data-carer');
+    bindConditional('hasSmsf', 'data-smsf');
+    bindConditional('hasTrust', 'data-trust');
 
     document.querySelectorAll('.col-form input, .col-form select').forEach((el) => {
       el.addEventListener('input', recalc);

--- a/src/js/advanced-v2.js
+++ b/src/js/advanced-v2.js
@@ -60,10 +60,19 @@ const PENSION_MEANS_TEST_DEFAULTS = {
 
 const COUNTRY_CODE_MAP = {
   portugal: 'PORTUGAL',
+  spain: 'SPAIN',
+  italy: 'ITALY',
+  canada: 'CANADA',
+  newzealand: 'NEW_ZEALAND',
   nz: 'NEW_ZEALAND',
+  japan: 'JAPAN',
+  india: 'INDIA',
+  usa: 'USA',
   thailand: 'THAILAND',
   vietnam: 'VIETNAM',
   malaysia: 'MALAYSIA',
+  bali: 'BALI',
+  philippines: 'PHILIPPINES',
 };
 
 const APP_STATE = {
@@ -326,7 +335,7 @@ function buildEngineInputs(inp) {
     carerReducedWorkPercent: inp.isCarer ? pct(inp.carerReducedWorkPercent) : 0,
     carerYearsExpected: inp.isCarer ? inp.carerYearsExpected : 0,
     agedParentsLocation: inp.agedParentsLocation || 'australia',
-    carerAnnualExpense: inp.isCarer ? (inp.carerAnnualExpense || inp.annualParentSupport || 0) : 0,
+    carerAnnualExpense: inp.isCarer ? (inp.carerAnnualExpense ?? inp.annualParentSupport ?? 0) : 0,
     privateSchool: inp.privateSchool,
     universitySupport: inp.uniSupport,
     educationCostPerChild: inp.educationCostPerChild,
@@ -338,13 +347,18 @@ function buildEngineInputs(inp) {
     spouseContribution: inp.spouseContribution,
     downsizeContribution: inp.useDownsizer,
     hasSMSF: inp.hasSmsf,
-    smsfAdminCosts: inp.smsfAdminCosts || 3500,
+    smsfAdminCosts: inp.smsfAdminCosts ?? 3500,
     smsfInvestmentStrategy: inp.smsfInvestmentStrategy || 'balanced',
     annualTravelBudget: 0,
     annualHobbyBudget: 0,
     legacyGoal: 0,
     legacyGoalType: 'none',
     enableProposedBudget2026: inp.budget2627,
+
+    goingOverseas: inp.goingOverseas,
+    overseasStartAge: inp.goingOverseas ? (inp.ageMovingOverseas || 0) : 0,
+    overseasAnnualBudget: inp.goingOverseas ? (inp.annualLivingCostOverseas || 0) : 0,
+    overseasReturnFrequency: inp.returnFrequency || 'never',
 
     creditCardBalance: inp.ccBalance,
     creditCardRate: pct(inp.ccRate || 20, 20),
@@ -354,6 +368,18 @@ function buildEngineInputs(inp) {
     carLoanRate: pct(inp.carLoanRate || 8, 8),
     hecsBalance: inp.hecsBalance,
   };
+}
+
+function deriveWithdrawSource(superBal, nonSuperBal) {
+  const s = superBal ?? 0;
+  const n = nonSuperBal ?? 0;
+  if (s <= 0 && n <= 0) return 'depleted';
+  if (s <= 0) return 'savings';
+  if (n <= 0) return 'super';
+  const superFraction = s / (s + n);
+  if (superFraction > 0.85) return 'super';
+  if (superFraction < 0.15) return 'savings';
+  return 'mixed';
 }
 
 function buildProjectionYears(inp, simulation) {
@@ -375,6 +401,9 @@ function buildProjectionYears(inp, simulation) {
     withdraw: Math.max(0, year.withdrawal || year.superIncome || 0),
     pension: Math.max(0, year.pensionIncome || 0),
     otherIncome: year.otherIncome || 0,
+    withdrawSource: deriveWithdrawSource(year.endSuperBalance, year.endNonSuperBalance),
+    overseasYear: year.overseasYear ?? false,
+    travelCost: year.travelCost ?? 0,
   }));
 
   if (accumulationHistory.length) {
@@ -392,6 +421,9 @@ function buildProjectionYears(inp, simulation) {
         withdraw: 0,
         pension: 0,
         otherIncome: 0,
+        withdrawSource: 'accumulating',
+        overseasYear: false,
+        travelCost: 0,
       }));
     return [...bridgeYears, ...retirementYears];
   }
@@ -594,6 +626,15 @@ function bindConditional(toggleId, containerAttr) {
   };
   tg.addEventListener('change', () => { apply(); recalc(); });
   apply();
+}
+
+function updateSmsfLowBalanceWarning() {
+  const warning = document.getElementById('smsfLowBalanceWarning');
+  if (!warning) return;
+  const hasSmsf = document.getElementById('hasSmsf');
+  const superBal = document.getElementById('superBal');
+  const balance = superBal ? (parseFloat(superBal.value) || 0) : 0;
+  warning.hidden = !(hasSmsf?.checked && balance < 300000);
 }
 
 // ============================================================
@@ -1120,9 +1161,11 @@ function buildOverseasAnalyzer(baseState) {
       retirementAge: baseState.input.retireAge,
       partnered: baseState.engineInputs?.isCouple,
       ageCameToAustralia: baseState.input.ageCameToAU,
-      australianResidenceYears: baseState.input.ageCameToAU > 0
-        ? Math.max(0, baseState.input.retireAge - baseState.input.ageCameToAU)
-        : Math.max(0, baseState.input.retireAge - 16),
+      australianResidenceYears: baseState.input.australianResidenceYears > 0
+        ? baseState.input.australianResidenceYears
+        : baseState.input.ageCameToAU > 0
+          ? Math.max(0, baseState.input.retireAge - baseState.input.ageCameToAU)
+          : Math.max(0, baseState.input.retireAge - 16),
       enableProposedBudget2026: baseState.input.budget2627,
     },
     {
@@ -1435,6 +1478,91 @@ function renderMonteCarloCharts(mc, inp) {
   }
 }
 
+function buildCareerImpactBlock(inp) {
+  if (!inp || !inp.age) return '';
+  const items = [];
+
+  // Caring for ageing parents
+  if (inp.isCarer && inp.carerYearsExpected > 0) {
+    const reducedPct = inp.carerReducedWorkPercent || 0;
+    const baseSalary = inp.salary || 0;
+    const annualIncomeLoss = baseSalary * (reducedPct / 100);
+    const totalIncomeLoss = annualIncomeLoss * inp.carerYearsExpected;
+    const superLoss = totalIncomeLoss * 0.12;
+    const yrs = inp.carerYearsExpected;
+    items.push(`
+      <div class="mc-stat">
+        <div class="mc-k">Caring for parents · ${yrs} yr${yrs > 1 ? 's' : ''}</div>
+        <div class="mc-v">−${reducedPct}% income</div>
+        <div class="mc-sub">Est. ${fmt$(totalIncomeLoss, { compact: true })} income · ${fmt$(superLoss, { compact: true })} super foregone</div>
+      </div>`);
+    if ((inp.carerAnnualExpense ?? inp.annualParentSupport) > 0) {
+      const expenseAmt = inp.carerAnnualExpense ?? inp.annualParentSupport;
+      items.push(`
+      <div class="mc-stat">
+        <div class="mc-k">Parent support cost</div>
+        <div class="mc-v">${fmt$(expenseAmt)}/yr</div>
+        <div class="mc-sub">Additional cash outflow during carer period</div>
+      </div>`);
+    }
+  }
+
+  // Reduced income before retirement (wind-down phase)
+  if (inp.reducedIncomeEnabled && inp.reducedIncomeAge > 0 && inp.reducedIncomeSalary >= 0) {
+    const retireAge = inp.retireAge || 65;
+    const yearsReduced = Math.max(0, retireAge - inp.reducedIncomeAge);
+    if (yearsReduced > 0) {
+      const annualDiff = Math.max(0, (inp.salary || 0) - inp.reducedIncomeSalary);
+      const cumulativeDiff = annualDiff * yearsReduced;
+      const superDiff = cumulativeDiff * 0.12;
+      items.push(`
+      <div class="mc-stat">
+        <div class="mc-k">Reduced income from age ${inp.reducedIncomeAge}</div>
+        <div class="mc-v">${fmt$(inp.reducedIncomeSalary)}/yr</div>
+        <div class="mc-sub">${yearsReduced} yr${yearsReduced > 1 ? 's' : ''} · ${fmt$(cumulativeDiff, { compact: true })} cumulative less · ${fmt$(superDiff, { compact: true })} super impact</div>
+      </div>`);
+    }
+  }
+
+  // Children's education costs
+  const numChildren = inp.dependents || 0;
+  if (numChildren > 0 && inp.educationCostPerChild > 0) {
+    const yearsPerChild = inp.privateSchool ? 13 : (inp.uniSupport ? 3 : 0);
+    const totalEd = numChildren * inp.educationCostPerChild * Math.max(1, yearsPerChild);
+    items.push(`
+      <div class="mc-stat">
+        <div class="mc-k">Education · ${numChildren} child${numChildren > 1 ? 'ren' : ''}</div>
+        <div class="mc-v">${fmt$(inp.educationCostPerChild)}/yr each</div>
+        <div class="mc-sub">${inp.privateSchool ? 'Private school (13 yrs)' : inp.uniSupport ? 'University support (3 yrs)' : 'Annual contribution'} · Est. ${fmt$(totalEd, { compact: true })} total</div>
+      </div>`);
+  }
+
+  // Overseas retirement cost summary
+  if (inp.goingOverseas && inp.ageMovingOverseas > 0 && inp.annualLivingCostOverseas > 0) {
+    const freq = inp.returnFrequency || 'never';
+    const travelPerPerson = { annually: 5000, biannually: 10000, quarterly: 20000, seasonal: 30000, never: 0 }[freq] ?? 0;
+    const travelTotal = travelPerPerson * (inp.household === 'couple' ? 2 : 1);
+    const overseasTotal = inp.annualLivingCostOverseas + travelTotal;
+    items.push(`
+      <div class="mc-stat">
+        <div class="mc-k">Overseas retirement from age ${inp.ageMovingOverseas}</div>
+        <div class="mc-v">${fmt$(overseasTotal)}/yr</div>
+        <div class="mc-sub">${fmt$(inp.annualLivingCostOverseas)} living + ${fmt$(travelTotal)} return travel (${freq})</div>
+      </div>`);
+  }
+
+  if (!items.length) return '';
+
+  return `
+    <div class="summary-chart" style="grid-column:1/-1">
+      <h5>Life events factored into this projection</h5>
+      <div class="desc">These irregular income changes and expenses are already modelled year-by-year in the simulation. Monte Carlo runs scatter investment returns and inflation around these values — the Year-by-Year table reflects their direct impact.</div>
+      <div class="mc-results-grid" style="margin-top:10px">
+        ${items.join('')}
+      </div>
+    </div>`;
+}
+
 function renderSummaryPanel() {
   const state = APP_STATE;
   const summaryItems = [
@@ -1521,6 +1649,8 @@ function renderSummaryPanel() {
       </div>
     </div>` : '';
 
+  const careerImpactBlock = buildCareerImpactBlock(inp);
+
   setPanelHtml('summary', `
     <div class="summary-grid">
       <div class="summary-chart">
@@ -1539,6 +1669,7 @@ function renderSummaryPanel() {
       ${monteCarloBlock}
     </div>
     ${recommendationLead}
+    ${careerImpactBlock}
     ${assumptionsBlock}
   `);
 }
@@ -1877,7 +2008,7 @@ function applyImportedUserData(userData) {
   }
 
   applyHouseholdVisibility();
-  ['investmentProperty', 'goingOverseas'].forEach((id) => {
+  ['investmentProperty', 'goingOverseas', 'isCarer', 'hasSmsf', 'hasTrust'].forEach((id) => {
     const checkbox = document.getElementById(id);
     if (checkbox) checkbox.dispatchEvent(new Event('change', { bubbles: true }));
   });
@@ -2186,16 +2317,48 @@ function paintYearTable(years, inp) {
     return '$' + Math.round(adjusted / 1000).toLocaleString('en-AU') + 'k';
   };
 
+  const SOURCE_LABEL = { super: 'Super', savings: 'Savings', mixed: 'Mixed', depleted: 'Depleted', accumulating: '' };
+  const SOURCE_CLASS = { super: 'src-super', savings: 'src-savings', mixed: 'src-mixed', depleted: 'src-depleted', accumulating: '' };
+
   body.innerHTML = years.slice(0, 60).map((y, i) => {
-    return `<tr class="${y.age === inp.retireAge ? 'retire' : ''} ${y.age >= inp.agePensionAge ? 'pension' : ''}">
-      <td>${y.year || (currentYear + i)}</td>
-      <td>${y.age}${y.age === inp.retireAge ? ' ★' : ''}</td>
-      <td>${formatAmount(y.superBalance, y.year)}</td>
-      <td>${formatAmount(y.nonSuperLiquidAssets, y.year)}</td>
-      <td>${formatAmount(y.totalAssets, y.year)}</td>
-      <td>${formatAmount(y.withdraw, y.year)}</td>
-      <td>${formatAmount(y.pension, y.year)}</td>
-      <td>${formatAmount((y.withdraw || 0) + (y.pension || 0) + (y.otherIncome || 0), y.year)}</td>
+    const calYear = y.year || (currentYear + i);
+    const retireFlag = y.age === inp.retireAge;
+    const pensionFlag = y.age >= inp.agePensionAge;
+    const isOverseas = y.overseasYear;
+    const travelCost = y.travelCost ?? 0;
+    const livingCost = Math.max(0, (y.withdraw || 0) - travelCost);
+    const srcLabel = SOURCE_LABEL[y.withdrawSource] || '';
+    const srcCls = SOURCE_CLASS[y.withdrawSource] || '';
+
+    const superTip = y.superBalance != null
+      ? `Super balance at end of year ${calYear}. ${y.age >= 60 ? 'Tax-free in pension phase.' : 'Preservation age not yet reached.'}`
+      : 'Super balance not available for this year.';
+
+    const nonSuperTip = y.nonSuperLiquidAssets != null
+      ? `Non-super liquid assets at end of year ${calYear}: cash, shares, ETFs and managed funds outside super.`
+      : 'Non-super balance not available for this year.';
+
+    const totalTip = `Total assets at end of year ${calYear}: super + non-super liquid + home equity + investment property equity.`;
+
+    const withdrawBreakdown = isOverseas
+      ? `Overseas living: ${formatAmount(livingCost, calYear)} + Return travel: ${formatAmount(travelCost, calYear)}. Source: ${srcLabel || '—'}.`
+      : `Annual portfolio withdrawal to fund living expenses. Primary source: ${srcLabel || '—'}.`;
+
+    const pensionTip = y.pension > 0
+      ? `Age Pension income for year ${calYear}. Amount reflects assets/income test and any AWLR portability adjustment.`
+      : `No Age Pension this year (assets/income test result or below pension age ${inp.agePensionAge}).`;
+
+    const incomeTip = `Total retirement income for year ${calYear}: withdrawals + Age Pension + investment property income + other sources.`;
+
+    return `<tr class="${retireFlag ? 'retire' : ''} ${pensionFlag ? 'pension' : ''} ${isOverseas ? 'overseas' : ''}">
+      <td title="Calendar year">${calYear}${isOverseas ? ' ✈' : ''}</td>
+      <td title="Age at start of year ${calYear}">${y.age}${retireFlag ? ' ★' : ''}</td>
+      <td title="${escapeHtml(superTip)}">${formatAmount(y.superBalance, calYear)}</td>
+      <td title="${escapeHtml(nonSuperTip)}">${formatAmount(y.nonSuperLiquidAssets, calYear)}</td>
+      <td title="${escapeHtml(totalTip)}">${formatAmount(y.totalAssets, calYear)}</td>
+      <td title="${escapeHtml(withdrawBreakdown)}">${formatAmount(y.withdraw, calYear)}${srcLabel ? ` <span class="wy-src ${escapeHtml(srcCls)}">${escapeHtml(srcLabel)}</span>` : ''}</td>
+      <td title="${escapeHtml(pensionTip)}">${formatAmount(y.pension, calYear)}</td>
+      <td title="${escapeHtml(incomeTip)}">${formatAmount((y.withdraw || 0) + (y.pension || 0) + (y.otherIncome || 0), calYear)}</td>
     </tr>`;
   }).join('');
 }
@@ -2328,6 +2491,15 @@ function boot() {
       el.addEventListener('input', recalc);
       el.addEventListener('change', recalc);
     });
+
+    ['hasSmsf', 'superBal'].forEach((id) => {
+      const el = document.getElementById(id);
+      if (el) {
+        el.addEventListener('change', updateSmsfLowBalanceWarning);
+        el.addEventListener('input', updateSmsfLowBalanceWarning);
+      }
+    });
+    updateSmsfLowBalanceWarning();
 
     applyHouseholdVisibility();
     applyAdvancedVisibility();

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -829,7 +829,15 @@ class RetirementCalculatorApp {
             // When TRUE, models: 14% rate (FY2027-28), WATO $250, $1,000 instant
             // deduction, CGT reform (inflation-indexed + 30% min).
             // These measures are NOT yet passed by Parliament.
-            enableProposedBudget2026: safeGetChecked('enableProposedBudget2026', false)
+            enableProposedBudget2026: safeGetChecked('enableProposedBudget2026', false),
+
+            // Overseas retirement — wire the Overseas tab fields into the simulator
+            // so the Year-by-Year projection uses the overseas living budget from
+            // the specified departure age instead of the domestic ASFA target.
+            goingOverseas: safeGetSelectValue('overseasCountry', '') !== '',
+            overseasStartAge: parseInt(safeGetValue('overseasAge', 0)) || 0,
+            overseasAnnualBudget: parseFormattedNumber(getRawValue('estimatedLivingCosts', '0')),
+            overseasReturnFrequency: safeGetSelectValue('returnFrequency', 'annually')
         };
 
         if (inputs.useGlidePath) {
@@ -2161,6 +2169,7 @@ class RetirementCalculatorApp {
         const retirementAge = inputs.retirementAge || 65;
 
         this.updateCurrentRetirementIncomePanel(result, inputs);
+        this.renderCareerImpactBanner(inputs);
 
         result.yearlyData.slice(0, 30).forEach(data => {
             if (data.depleted) {
@@ -2183,18 +2192,36 @@ class RetirementCalculatorApp {
             }
 
             const isRetirementYear = data.age === retirementAge || (data.yourAge === retirementAge);
-            const rowClass = isRetirementYear ? 'retirement-row' : '';
+            const isOverseas = data.overseasYear === true;
+            const rowClass = [isRetirementYear ? 'retirement-row' : '', isOverseas ? 'overseas-row' : ''].filter(Boolean).join(' ');
             const endBal = data.endBalance || 0;
             const netWorth = endBal + (data.nonLiquidAssets || 0);
 
+            // Derive withdrawal funding source from super/non-super balance split
+            const superBal = data.endSuperBalance ?? 0;
+            const nonSuperBal = data.endNonSuperBalance ?? 0;
+            let srcLabel = '', srcClass = '';
+            if (superBal > 0 || nonSuperBal > 0) {
+                const superFrac = (superBal + nonSuperBal) > 0 ? superBal / (superBal + nonSuperBal) : 0;
+                if (superFrac > 0.85)      { srcLabel = 'Super';   srcClass = 'src-super'; }
+                else if (superFrac < 0.15) { srcLabel = 'Savings'; srcClass = 'src-savings'; }
+                else                        { srcLabel = 'Mixed';   srcClass = 'src-mixed'; }
+            }
+
+            const travelCost = data.travelCost ?? 0;
+            const livingCost = Math.max(0, (data.withdrawal || 0) - travelCost);
+            const withdrawTip = isOverseas
+                ? `Overseas living: ${formatCurrency(livingCost)} + Return travel: ${formatCurrency(travelCost)}. Source: ${srcLabel || '—'}.`
+                : `Annual portfolio withdrawal. Source: ${srcLabel || '—'}.`;
+
             projectionTable.innerHTML += `
                 <tr class="${rowClass}">
-                    <td class="px-4 py-2 age-cell">${data.year}${isRetirementYear ? ' <span title="Retirement year" style="color:var(--color-gold-500)">★</span>' : ''}</td>
+                    <td class="px-4 py-2 age-cell">${data.year}${isRetirementYear ? ' <span title="Retirement year" style="color:var(--color-gold-500)">★</span>' : ''}${isOverseas ? ' <span title="Overseas retirement year" style="color:#0d9488">✈</span>' : ''}</td>
                     <td class="px-4 py-2 age-cell">${ageDisplay}</td>
                     <td class="px-4 py-2 num">${formatCurrency(data.startBalance)}</td>
                     <td class="px-4 py-2 num">${formatCurrency(data.nonLiquidAssets || 0)}</td>
                     <td class="px-4 py-2 num positive">+${formatCurrency(data.growth || 0)}</td>
-                    <td class="px-4 py-2 num negative">-${formatCurrency(data.withdrawal || 0)}</td>
+                    <td class="px-4 py-2 num negative" title="${withdrawTip}">-${formatCurrency(data.withdrawal || 0)}${srcLabel ? `<span class="wy-src ${srcClass}">${srcLabel}</span>` : ''}</td>
                     <td class="px-4 py-2 num positive">+${formatCurrency(data.propertyIncome || 0)}</td>
                     <td class="px-4 py-2 num negative">-${formatCurrency(data.healthcareCost)}</td>
                     <td class="px-4 py-2 num negative">-${formatCurrency(data.agedCareCost)}</td>
@@ -2203,6 +2230,49 @@ class RetirementCalculatorApp {
                 </tr>
             `;
         });
+    }
+
+    renderCareerImpactBanner(inputs) {
+        const container = $('careerImpactBanner');
+        if (!container) return;
+        const items = [];
+
+        if (inputs.isCarerForParents && inputs.carerYearsExpected > 0) {
+            const pct = Math.round((inputs.carerReducedWorkPercent || 0) * 100);
+            const annualLoss = (inputs.yourSalary || 0) * (inputs.carerReducedWorkPercent || 0);
+            const totalLoss = annualLoss * inputs.carerYearsExpected;
+            const superLoss = totalLoss * 0.12;
+            items.push(`<span class="inline-flex items-center gap-1 px-2 py-1 rounded bg-amber-50 border border-amber-200 text-amber-800 text-xs font-medium">👴 Carer ${inputs.carerYearsExpected} yr${inputs.carerYearsExpected > 1 ? 's' : ''} at −${pct}% income · ~${formatCurrency(totalLoss)} income / ~${formatCurrency(superLoss)} super foregone</span>`);
+            if ((inputs.carerAnnualExpense || 0) > 0) {
+                items.push(`<span class="inline-flex items-center gap-1 px-2 py-1 rounded bg-amber-50 border border-amber-200 text-amber-800 text-xs font-medium">💸 Parent support ${formatCurrency(inputs.carerAnnualExpense)}/yr during carer period</span>`);
+            }
+        }
+
+        if (inputs.enableReducedIncome && inputs.reducedIncomeAge > 0) {
+            const yrs = Math.max(0, (inputs.retirementAge || 65) - inputs.reducedIncomeAge);
+            if (yrs > 0) {
+                const diff = Math.max(0, (inputs.yourSalary || 0) - (inputs.reducedIncomeSalary || 0));
+                items.push(`<span class="inline-flex items-center gap-1 px-2 py-1 rounded bg-blue-50 border border-blue-200 text-blue-800 text-xs font-medium">📉 Reduced income age ${inputs.reducedIncomeAge}→${inputs.retirementAge}: ${formatCurrency(inputs.reducedIncomeSalary)}/yr · ~${formatCurrency(diff * yrs)} cumulative difference</span>`);
+            }
+        }
+
+        if (inputs.dependents > 0 && inputs.educationCostPerChild > 0) {
+            items.push(`<span class="inline-flex items-center gap-1 px-2 py-1 rounded bg-green-50 border border-green-200 text-green-800 text-xs font-medium">🎓 Education ${formatCurrency(inputs.educationCostPerChild)}/yr × ${inputs.dependents} child${inputs.dependents > 1 ? 'ren' : ''}${inputs.privateSchool ? ' (private school)' : ''}</span>`);
+        }
+
+        if (inputs.goingOverseas && inputs.overseasStartAge > 0) {
+            const travelPerPerson = { annually: 5000, biannually: 10000, quarterly: 20000, seasonal: 30000, never: 0 }[inputs.overseasReturnFrequency] ?? 0;
+            const travelTotal = travelPerPerson * (inputs.isCouple ? 2 : 1);
+            items.push(`<span class="inline-flex items-center gap-1 px-2 py-1 rounded bg-teal-50 border border-teal-200 text-teal-800 text-xs font-medium">✈ Overseas from age ${inputs.overseasStartAge}: ${formatCurrency(inputs.overseasAnnualBudget)}/yr living + ${formatCurrency(travelTotal)}/yr return travel</span>`);
+        }
+
+        container.innerHTML = items.length
+            ? `<div class="mb-4 p-3 rounded-lg border border-gray-200 bg-gray-50">
+                <p class="text-xs font-semibold text-gray-600 uppercase tracking-wide mb-2">Life events modelled in this projection</p>
+                <div class="flex flex-wrap gap-2">${items.join('')}</div>
+                <p class="text-xs text-gray-400 mt-2">These irregular income changes and expenses are modelled year-by-year. Monte Carlo scatters returns and inflation around these values.</p>
+               </div>`
+            : '';
     }
 
     // Populate the Moneysmart-style "Your current retirement income" headline
@@ -8321,16 +8391,23 @@ class RetirementCalculatorApp {
         const hasSMSF = document.getElementById('hasSMSF');
         const smsfSection = document.getElementById('smsfSection');
         if (hasSMSF && smsfSection) {
+            const updateSmsfWarning = () => {
+                if (!hasSMSF.checked) return;
+                const superBalance = (safeGetValue('yourCurrentSuper', 0) || 0) +
+                    (safeGetValue('partnerCurrentSuper', 0) || 0);
+                const warning = document.getElementById('smsfLowBalanceWarning');
+                if (warning) warning.classList.toggle('hidden', superBalance >= 300000);
+            };
             const toggleSMSF = () => {
                 smsfSection.classList.toggle('hidden', !hasSMSF.checked);
-                if (hasSMSF.checked) {
-                    const superBalance = (safeGetValue('yourCurrentSuper', 0) || 0) +
-                        (safeGetValue('partnerCurrentSuper', 0) || 0);
-                    const warning = document.getElementById('smsfLowBalanceWarning');
-                    if (warning) warning.classList.toggle('hidden', superBalance >= 300000);
-                }
+                updateSmsfWarning();
             };
             hasSMSF.addEventListener('change', toggleSMSF);
+            // Re-check warning whenever super balances change
+            ['yourCurrentSuper', 'partnerCurrentSuper'].forEach(id => {
+                const el = document.getElementById(id);
+                if (el) { el.addEventListener('input', updateSmsfWarning); el.addEventListener('change', updateSmsfWarning); }
+            });
             toggleSMSF();
         }
 

--- a/src/js/simulator.js
+++ b/src/js/simulator.js
@@ -220,6 +220,11 @@ export class RetirementSimulator {
         return annualCost * (agedCareProfile.costWeight || 0);
     }
 
+    static getAnnualTravelCost(frequency, isCouple) {
+        const perPerson = { annually: 5000, biannually: 10000, quarterly: 20000, seasonal: 30000, never: 0 }[frequency] ?? 0;
+        return perPerson * (isCouple ? 2 : 1);
+    }
+
     buildRetirementSpendingPlan({
         inputs,
         retirementYear,
@@ -228,9 +233,27 @@ export class RetirementSimulator {
         initialRetirementBalance,
         previousSpendingTarget,
         agedCareActive,
-        useRandomReturns
+        useRandomReturns,
+        overrideInflationFactor,
     }) {
-        const inflationFactor = Math.pow(1 + inputs.inflation, retirementYear);
+        const inflationFactor = overrideInflationFactor ?? Math.pow(1 + inputs.inflation, retirementYear);
+
+        // Overseas phase: substitute overseas living budget + return travel cost
+        if (inputs.goingOverseas && inputs.overseasStartAge > 0 && currentAge >= inputs.overseasStartAge) {
+            const travelCost = RetirementSimulator.getAnnualTravelCost(inputs.overseasReturnFrequency, inputs.isCouple);
+            const totalOverseasCost = (inputs.overseasAnnualBudget + travelCost) * inflationFactor;
+            const essentialSpending = totalOverseasCost * 0.85;
+            return {
+                lifecycleStage: 'overseas',
+                lifecycleLabel: 'Overseas retirement',
+                decumulationStrategy: 'overseas_fixed',
+                essentialSpending,
+                discretionarySpending: totalOverseasCost - essentialSpending,
+                targetSpending: totalOverseasCost,
+                overseasTravelCost: travelCost * inflationFactor,
+            };
+        }
+
         const travelHobbyBase = (inputs.annualTravelBudget || 0) + (inputs.annualHobbyBudget || 0);
         const pensionAge = this.config.OVERSEAS_RETIREMENT?.PENSION_AGE || 67;
         const lifecycle = this.getRetirementLifecycleStage(
@@ -1663,6 +1686,11 @@ export class RetirementSimulator {
         const initialRetirementBalance = currentBalance;
         const agedCareProfile = this.buildAgedCareProfile(inputs, useRandomReturns, effectiveYourLifespan);
         let previousSpendingTarget = null;
+        // Per-year inflation scatter: each Monte Carlo run experiences a different inflation path
+        // centred on the user's input, giving realistic variability in spending targets.
+        // Seed with deterministic pre-retirement inflation so year-0 of retirement correctly
+        // expresses spending targets in retirement-year dollars (not today's dollars).
+        let cumulativeInflationFactor = Math.pow(1 + inputs.inflation, yearsToRetirement);
 
         for (let i = 0; i < yearsInRetirement; i++) {
             const retirementYear = yearsToRetirement + i;
@@ -1749,10 +1777,18 @@ export class RetirementSimulator {
                 initialRetirementBalance,
                 previousSpendingTarget,
                 agedCareActive: agedCareCost > 0,
-                useRandomReturns
+                useRandomReturns,
+                overrideInflationFactor: useRandomReturns ? cumulativeInflationFactor : undefined,
             });
             const baseIncomeNeeded = spendingPlan.targetSpending;
             previousSpendingTarget = baseIncomeNeeded;
+
+            // Advance the cumulative inflation factor for the next retirement year.
+            // Multiplying AFTER using the factor ensures year i uses the correct base.
+            if (useRandomReturns) {
+                const yearInflation = Math.max(0.005, randomNormal(inputs.inflation, inputs.inflation * 0.25));
+                cumulativeInflationFactor *= (1 + yearInflation);
+            }
 
             // LHC loading cost during retirement (mirrors accumulation loop logic)
             let lhcRetirementCost = 0;
@@ -2057,7 +2093,11 @@ export class RetirementSimulator {
                 endNonSuperBalance: displayNonSuperBalance,
                 liquidAssets,
                 nonLiquidAssets,
-                depleted: false
+                depleted: false,
+                overseasYear: !!(inputs.goingOverseas && inputs.overseasStartAge > 0 && yourCurrentAge >= inputs.overseasStartAge),
+                // Use the inflated travel cost already computed inside buildRetirementSpendingPlan
+                // so the tooltip breakdown (living cost = withdraw - travelCost) is consistent.
+                travelCost: spendingPlan.overseasTravelCost ?? 0,
             };
 
             // Add pension details for first year if available

--- a/tests/unit/advanced-v2-engine-adapter.test.js
+++ b/tests/unit/advanced-v2-engine-adapter.test.js
@@ -60,6 +60,7 @@ const buildRedesignInputs = (overrides = {}) => ({
     uniSupport: false,
     isCarer: false,
     annualParentSupport: 0,
+    carerAnnualExpense: undefined,
     carerReducedWorkPercent: 0,
     carerYearsExpected: 0,
     homeValue: 850000,
@@ -83,7 +84,14 @@ const buildRedesignInputs = (overrides = {}) => ({
     ipGrowthRate: 4,
     ipState: '',
     hasSmsf: false,
+    smsfAdminCosts: undefined,
     hasTrust: false,
+    trustNetAssets: 0,
+    trustAttributionPercentage: 100,
+    trustAnnualDistributions: 0,
+    trustTaxRate: 30,
+    familyTrustIncomeDistribution: 0,
+    beneficiaryAllocation: 100,
     desiredIncome: 73000,
     hasPrivateHospital: true,
     healthCondition: 'good',
@@ -300,7 +308,62 @@ describe('advanced-v2 engine adapter', () => {
     test('maps redesign overseas destinations to analyzer country codes', () => {
         expect(mapDestinationCode('portugal')).toBe('PORTUGAL');
         expect(mapDestinationCode('nz')).toBe('NEW_ZEALAND');
+        expect(mapDestinationCode('newzealand')).toBe('NEW_ZEALAND');
+        expect(mapDestinationCode('spain')).toBe('SPAIN');
+        expect(mapDestinationCode('italy')).toBe('ITALY');
+        expect(mapDestinationCode('canada')).toBe('CANADA');
+        expect(mapDestinationCode('japan')).toBe('JAPAN');
+        expect(mapDestinationCode('india')).toBe('INDIA');
+        expect(mapDestinationCode('usa')).toBe('USA');
+        expect(mapDestinationCode('bali')).toBe('BALI');
+        expect(mapDestinationCode('philippines')).toBe('PHILIPPINES');
         expect(mapDestinationCode('')).toBeNull();
+    });
+
+    test('maps SMSF fields with nullish coalescing — explicit 0 is preserved', () => {
+        const withZero = buildEngineInputs(buildRedesignInputs({ hasSmsf: true, smsfAdminCosts: 0 }));
+        expect(withZero.hasSMSF).toBe(true);
+        expect(withZero.smsfAdminCosts).toBe(0);
+
+        const withDefault = buildEngineInputs(buildRedesignInputs({ hasSmsf: true }));
+        expect(withDefault.smsfAdminCosts).toBe(3500);
+    });
+
+    test('maps trust fields with correct percent-to-ratio conversions', () => {
+        const engineInputs = buildEngineInputs(buildRedesignInputs({
+            hasTrust: true,
+            trustType: 'discretionary',
+            trustControlLevel: 'high',
+            trustNetAssets: 500000,
+            trustAttributionPercentage: 80,
+            trustAnnualDistributions: 20000,
+            trustTaxRate: 15,
+            familyTrustIncomeDistribution: 10000,
+            beneficiaryAllocation: 50,
+        }));
+
+        expect(engineInputs.hasTrustAssets).toBe(true);
+        expect(engineInputs.trustNetAssets).toBe(500000);
+        expect(engineInputs.trustAttributionPercentage).toBeCloseTo(0.8);
+        expect(engineInputs.trustTaxRate).toBeCloseTo(0.15);
+        expect(engineInputs.beneficiaryAllocation).toBeCloseTo(0.5);
+        expect(engineInputs.trustAnnualDistributions).toBe(20000);
+        expect(engineInputs.familyTrustIncomeDistribution).toBe(10000);
+    });
+
+    test('carerAnnualExpense uses nullish coalescing — explicit 0 is not replaced by annualParentSupport', () => {
+        const withExplicitZero = buildEngineInputs(buildRedesignInputs({
+            isCarer: true,
+            carerAnnualExpense: 0,
+            annualParentSupport: 8000,
+        }));
+        expect(withExplicitZero.carerAnnualExpense).toBe(0);
+
+        const withFallback = buildEngineInputs(buildRedesignInputs({
+            isCarer: true,
+            annualParentSupport: 8000,
+        }));
+        expect(withFallback.carerAnnualExpense).toBe(8000);
     });
 
     test('normalises risk profile summary for export and rendering', () => {


### PR DESCRIPTION
## Summary

- **Section 4 — Family carer:** `agedParentsLocation` (dropdown: AU citizen / non-citizen / Overseas / Mixed) and `carerAnnualExpense` (annual financial support to parents) added as conditional fields revealed when the carer toggle is on. Existing `carerReducedWorkPercent` and `carerYearsExpected` are moved into the same conditional block for consistency.

- **Section 6 — SMSF:** Full SMSF section added behind the toggle: `smsfAdminCosts`, `smsfInvestmentStrategy` (5 strategy options), a low-balance warning notice, and regulatory guidance linking to the SMSF guide.

- **Section 6 — Trust:** All 11 trust attribution fields added behind the toggle: `trustType`, `trustControlLevel`, `trustNetAssets`, `trustAttributionPercentage`, `trustAnnualDistributions`, `trustTaxRate`, `familyTrustIncomeDistribution`, `beneficiaryAllocation`, and checkboxes for `homeInTrust`, `investmentPropertyInTrust`, `stocksInTrust`.

- **Section 12 — Overseas:** Expanded from 4 fields to 22. Destination dropdown now has 15 countries (SSA vs non-SSA grouped). New fields: `australianResidenceYears`, `returnFrequency`, `overseasMoveType`, `overseasTaxResidency`, `overseasHealthCover`, `overseasAgreementCountry`, `maintainResidency`, `propertyStrategy`, `trustBeneficiaries`, `superAccess`, `estimatedLivingCosts`, `overseasSpendingCurrency`, `overseasAudFxChange`, `overseasHousingType`, `overseasAnnualRent`, `overseasFallbackAge`, `overseasFallbackTrigger`. Includes collapsible key overseas rules reference (March 2026 rates).

- **JS (`advanced-v2.js`):** Three new `bindConditional` calls wired (`data-carer`, `data-smsf`, `data-trust`). All 32 new fields read in `readInputs()`. `buildEngineInputs()` now uses actual trust and SMSF input values instead of hardcoded defaults. `carerAnnualExpense` prefers the dedicated field over the legacy `annualParentSupport` alias.

## Test plan

- [x] Toggle "I am a carer" in Section 4 — carer fields appear/disappear; check `agedParentsLocation` and `carerAnnualExpense` are visible
- [x] Toggle SMSF in Section 6 — SMSF cost and strategy fields appear; regulatory notice visible
- [x] Toggle Trust in Section 6 — all 11 trust fields appear; checkboxes work
- [x] Enable Overseas in Section 12 — all 22 fields visible; SSA country grouping correct; key rules collapsible works
- [x] Run simulation with each section toggled on — no JS errors in console, values passed to engine
- [x] Save/load data round-trip — new field values persist correctly
