### PR TITLE
Advanced calculator: 6-phase audit and enhancement

### DIFF
--- a/src/advanced-v2.html
+++ b/src/advanced-v2.html
@@ -1208,7 +1208,7 @@
           <svg class="section-chev" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
         </button>
         <div class="section-body">
-          <div class="notice"><span class="ic">🏠</span><div>These optional settings model real costs that typically arise in later retirement. All are disabled by default — enable only what applies to your situation. Linked to your downsize plan: if you downsize to strata/aged care, maintenance costs are automatically removed.</div></div>
+          <div class="notice"><span class="ic">🏠</span><div>These optional settings model real costs that typically arise in later retirement. All are disabled by default — enable only what applies to your situation. Linked to your downsize plan: if you plan to downsize, ongoing maintenance costs are automatically removed.</div></div>
 
           <!-- ── Home modifications ── -->
           <div class="subhead">Home modifications</div>

--- a/src/advanced-v2.html
+++ b/src/advanced-v2.html
@@ -897,7 +897,7 @@
           <div class="fields three">
             <div class="field">
               <label class="field-label" for="mcRuns"><span>Monte Carlo runs</span></label>
-              <div class="field-input"><select id="mcRuns"><option value="200">200 (quick)</option><option value="500" selected>500 (recommended)</option><option value="1000">1,000 (detailed)</option><option value="5000">5,000 (slower)</option><option value="10000">10,000 (thorough)</option><option value="custom">Custom…</option></select></div>
+              <div class="field-input"><select id="mcRuns"><option value="200">200 (quick)</option><option value="500" selected>500 (recommended)</option><option value="1000">1,000 (detailed)</option><option value="5000">5,000 (slower)</option><option value="10000">10,000 (thorough)</option><option value="20000">20,000 (exhaustive — slow)</option><option value="custom">Custom…</option></select></div>
               <div id="mcRunsCustomWrap" style="display:none;margin-top:6px;flex-direction:column;gap:4px">
                 <div class="field-input"><input id="mcRunsCustom" type="number" value="2000" min="100" max="20000" step="100" placeholder="100 – 20,000" /><span class="suffix">runs</span></div>
                 <div class="field-help">Enter a value between 100 and 20,000. Values above 10,000 may take 30–60 seconds.</div>
@@ -1199,7 +1199,110 @@
         </div>
       </section>
 
-      <!-- ──────────── ACTION STRIP ──────────── -->
+      <!-- ──────────── 13 · AGE-RELATED OPTIONAL COSTS (advanced) ──────────── -->
+      <section class="section" data-section="age-options" data-advanced="true">
+        <button class="section-head" type="button">
+          <span class="section-num">13</span>
+          <span class="section-title"><h3>Age-related optional costs</h3><small>Home modifications, annuity income, tiered spending</small></span>
+          <span class="section-meta"><span class="pill">optional</span></span>
+          <svg class="section-chev" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
+        </button>
+        <div class="section-body">
+          <div class="notice"><span class="ic">🏠</span><div>These optional settings model real costs that typically arise in later retirement. All are disabled by default — enable only what applies to your situation. Linked to your downsize plan: if you downsize to strata/aged care, maintenance costs are automatically removed.</div></div>
+
+          <!-- ── Home modifications ── -->
+          <div class="subhead">Home modifications</div>
+          <div class="fields one">
+            <div class="field">
+              <label class="toggle"><input id="enableHomeModifications" type="checkbox" /><span class="track"></span><span class="label">Plan for home accessibility modifications</span></label>
+              <div class="field-help">One-off cost to adapt your home for mobility or safety (ramps, grab rails, bathroom refit, etc.).</div>
+            </div>
+          </div>
+          <div data-home-mods="true" hidden>
+            <div class="fields three">
+              <div class="field">
+                <label class="field-label" for="homeModificationCost"><span>Estimated modification cost</span></label>
+                <div class="field-input has-prefix"><span class="prefix">$</span><input id="homeModificationCost" type="number" value="25000" step="1000" min="0" /></div>
+                <div class="field-help">National average ~$15,000–$35,000. Larger homes or comprehensive retrofits may reach $80,000+.</div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="homeModificationAge"><span>Expected age for modifications</span></label>
+                <div class="field-input"><input id="homeModificationAge" type="number" value="78" min="60" max="100" /><span class="suffix">yrs</span></div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="homeModificationRecurring"><span>Annual ongoing maintenance</span><span class="hint">after mods</span></label>
+                <div class="field-input has-prefix"><span class="prefix">$</span><input id="homeModificationRecurring" type="number" value="2000" step="250" min="0" /></div>
+                <div class="field-help">Annual upkeep of accessibility features. Set to $0 if downsizing to strata/aged care (maintenance is covered by levies).</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- ── Longevity insurance / annuity ── -->
+          <div class="subhead">Longevity insurance (annuity)</div>
+          <div class="fields one">
+            <div class="field">
+              <label class="toggle"><input id="enableAnnuity" type="checkbox" /><span class="track"></span><span class="label">Purchase a lifetime annuity</span></label>
+              <div class="field-help">Model the purchase of a guaranteed income stream (annuity or similar product like a Lifetime Income Stream) at a specific age. This provides certainty against outliving your super.</div>
+            </div>
+          </div>
+          <div data-annuity="true" hidden>
+            <div class="fields three">
+              <div class="field">
+                <label class="field-label" for="annuityPurchaseAge"><span>Age of annuity purchase</span></label>
+                <div class="field-input"><input id="annuityPurchaseAge" type="number" value="67" min="55" max="90" /><span class="suffix">yrs</span></div>
+                <div class="field-help">Typically purchased at or just after retirement age for maximum guaranty period.</div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="annuityLumpSum"><span>Purchase lump sum</span></label>
+                <div class="field-input has-prefix"><span class="prefix">$</span><input id="annuityLumpSum" type="number" value="200000" step="10000" min="0" /></div>
+                <div class="field-help">Amount drawn from super/savings to purchase the annuity. Removed from your portfolio at the purchase age.</div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="annuityAnnualIncome"><span>Annual guaranteed income</span></label>
+                <div class="field-input has-prefix"><span class="prefix">$</span><input id="annuityAnnualIncome" type="number" value="14000" step="500" min="0" /></div>
+                <div class="field-help">Annual income received from the annuity for life. Typical payout rate ~6–8% of lump sum for a 67-year-old.</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- ── Tiered spending (Active / Stable / Frail) ── -->
+          <div class="subhead">Tiered spending by retirement stage</div>
+          <div class="fields one">
+            <div class="field">
+              <label class="toggle"><input id="enableTieredSpending" type="checkbox" /><span class="track"></span><span class="label">Apply tiered spending multipliers (Active → Stable → Frail)</span></label>
+              <div class="field-help">Research shows retirement spending follows a "smile" curve. The early "Active" years have high lifestyle spending; the middle "Stable" years decline; the late "Frail" years rise sharply due to care costs. Enable to apply custom multipliers per stage.</div>
+            </div>
+          </div>
+          <div data-tiered-spending="true" hidden>
+            <div class="fields">
+              <div class="field">
+                <label class="field-label" for="tieredSpendingActiveAge"><span>Active stage ends at age</span></label>
+                <div class="field-input"><input id="tieredSpendingActiveAge" type="number" value="75" min="65" max="85" /><span class="suffix">yrs</span></div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="tieredSpendingFrailAge"><span>Frail stage begins at age</span></label>
+                <div class="field-input"><input id="tieredSpendingFrailAge" type="number" value="85" min="70" max="100" /><span class="suffix">yrs</span></div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="tieredSpendingActiveMultiplier"><span>Active stage spending</span><span class="hint">% of base</span></label>
+                <div class="field-input"><input id="tieredSpendingActiveMultiplier" type="number" value="110" min="80" max="150" step="5" /><span class="suffix">%</span></div>
+                <div class="field-help">Default 110% — early retirees typically spend 10% more on travel and lifestyle.</div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="tieredSpendingStableMultiplier"><span>Stable stage spending</span><span class="hint">% of base</span></label>
+                <div class="field-input"><input id="tieredSpendingStableMultiplier" type="number" value="90" min="60" max="120" step="5" /><span class="suffix">%</span></div>
+                <div class="field-help">Default 90% — mid-retirement spending typically falls as travel and activity decline.</div>
+              </div>
+              <div class="field">
+                <label class="field-label" for="tieredSpendingFrailMultiplier"><span>Frail stage spending</span><span class="hint">% of base</span></label>
+                <div class="field-input"><input id="tieredSpendingFrailMultiplier" type="number" value="115" min="90" max="200" step="5" /><span class="suffix">%</span></div>
+                <div class="field-help">Default 115% — late retirement includes higher healthcare and care costs.</div>
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </section>
       <div class="action-strip" style="display:grid;grid-template-columns:1fr auto;gap:14px;padding:14px;background:var(--surface);border:1px solid var(--border);border-radius:16px;align-items:center">
         <div style="display:flex;gap:8px;flex-wrap:wrap;align-items:center">
           <span style="font-size:11.5px;color:var(--ink-3);letter-spacing:.08em;text-transform:uppercase;font-weight:600;margin-right:4px">Step 2 — Explore</span>

--- a/src/advanced.html
+++ b/src/advanced.html
@@ -3697,6 +3697,98 @@
                                value="75000" min="0">
                     </div>
                 </div>
+
+                <!-- Age-Related Optional Costs (mirrors advanced-v2.html Section 13) -->
+                <div class="mt-4 p-4 bg-orange-50 border border-orange-200 rounded-lg">
+                    <h4 class="text-sm font-semibold text-orange-800 mb-3">Age-Related Optional Costs
+                        <span class="section-badge badge-optional ml-2">Optional</span>
+                    </h4>
+                    <p class="text-xs text-orange-700 mb-3">Toggle the scenarios you want to model. Costs are applied in the simulation when the trigger age is reached. If downsizing to a newer/strata property is planned, maintenance costs may drop but body-corporate fees may apply.</p>
+
+                    <!-- Home Modifications -->
+                    <div class="mb-3 p-3 bg-white border border-orange-100 rounded">
+                        <label class="flex items-center gap-2 font-medium text-sm text-gray-700 mb-2">
+                            <input type="checkbox" id="enableHomeModifications" class="rounded border-gray-300 text-orange-500">
+                            🏠 Home Modifications &amp; Accessibility
+                        </label>
+                        <div id="homeModsFields" style="display:none" class="grid grid-cols-2 gap-2 mt-2">
+                            <div>
+                                <label class="block text-xs font-medium text-gray-700" for="homeModificationCost">One-off Modification Cost ($)</label>
+                                <input class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm" id="homeModificationCost" type="text" value="25000" min="0" placeholder="e.g. 25000">
+                                <p class="text-xs text-gray-500 mt-0.5">Ramps, grab rails, bathroom modifications</p>
+                            </div>
+                            <div>
+                                <label class="block text-xs font-medium text-gray-700" for="homeModificationAge">Age to Apply Cost</label>
+                                <input class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm" id="homeModificationAge" type="text" value="75" min="60" max="100" placeholder="e.g. 75">
+                                <p class="text-xs text-gray-500 mt-0.5">Typically 75–80 years</p>
+                            </div>
+                            <div class="col-span-2">
+                                <label class="block text-xs font-medium text-gray-700" for="homeModificationRecurring">Annual Recurring Cost ($)</label>
+                                <input class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm" id="homeModificationRecurring" type="text" value="2000" min="0" placeholder="e.g. 2000">
+                                <p class="text-xs text-gray-500 mt-0.5">Ongoing home help, garden care after modification age. 0 if downsizing to managed facility.</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Longevity Insurance / Annuity -->
+                    <div class="mb-3 p-3 bg-white border border-orange-100 rounded">
+                        <label class="flex items-center gap-2 font-medium text-sm text-gray-700 mb-2">
+                            <input type="checkbox" id="enableAnnuity" class="rounded border-gray-300 text-orange-500">
+                            🛡️ Longevity Insurance / Annuity
+                        </label>
+                        <div id="annuityFields" style="display:none" class="grid grid-cols-2 gap-2 mt-2">
+                            <div>
+                                <label class="block text-xs font-medium text-gray-700" for="annuityPurchaseAge">Purchase Age</label>
+                                <input class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm" id="annuityPurchaseAge" type="text" value="67" min="55" max="80" placeholder="e.g. 67">
+                                <p class="text-xs text-gray-500 mt-0.5">Age when you buy the annuity</p>
+                            </div>
+                            <div>
+                                <label class="block text-xs font-medium text-gray-700" for="annuityLumpSum">Annuity Purchase Price ($)</label>
+                                <input class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm" id="annuityLumpSum" type="text" value="200000" min="0" placeholder="e.g. 200000">
+                                <p class="text-xs text-gray-500 mt-0.5">Lump sum invested in annuity</p>
+                            </div>
+                            <div class="col-span-2">
+                                <label class="block text-xs font-medium text-gray-700" for="annuityAnnualIncome">Annual Annuity Income ($)</label>
+                                <input class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm" id="annuityAnnualIncome" type="text" value="12000" min="0" placeholder="e.g. 12000">
+                                <p class="text-xs text-gray-500 mt-0.5">Guaranteed annual income from annuity — reduces portfolio drawdown after purchase age</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Tiered Spending (Active / Stable / Frail) -->
+                    <div class="p-3 bg-white border border-orange-100 rounded">
+                        <label class="flex items-center gap-2 font-medium text-sm text-gray-700 mb-2">
+                            <input type="checkbox" id="enableTieredSpending" class="rounded border-gray-300 text-orange-500">
+                            📉 Tiered Spending Stages
+                        </label>
+                        <p class="text-xs text-gray-500 mb-2">Research shows retirement spending typically follows an Active → Stable → Frail pattern, falling in the middle years before rising for late-life care.</p>
+                        <div id="tieredSpendingFields" style="display:none" class="grid grid-cols-2 gap-2 mt-2">
+                            <div>
+                                <label class="block text-xs font-medium text-gray-700" for="tieredSpendingActiveAge">Active Phase End Age</label>
+                                <input class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm" id="tieredSpendingActiveAge" type="text" value="75" min="60" max="85" placeholder="e.g. 75">
+                            </div>
+                            <div>
+                                <label class="block text-xs font-medium text-gray-700" for="tieredSpendingFrailAge">Frail Phase Start Age</label>
+                                <input class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm" id="tieredSpendingFrailAge" type="text" value="85" min="70" max="100" placeholder="e.g. 85">
+                            </div>
+                            <div>
+                                <label class="block text-xs font-medium text-gray-700" for="tieredSpendingActiveMultiplier">Active Phase Spending (%)</label>
+                                <input class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm" id="tieredSpendingActiveMultiplier" type="text" value="110" min="80" max="150" placeholder="e.g. 110">
+                                <p class="text-xs text-gray-500 mt-0.5">% of base spending — typically higher in early retirement (travel, leisure)</p>
+                            </div>
+                            <div>
+                                <label class="block text-xs font-medium text-gray-700" for="tieredSpendingStableMultiplier">Stable Phase Spending (%)</label>
+                                <input class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm" id="tieredSpendingStableMultiplier" type="text" value="90" min="50" max="120" placeholder="e.g. 90">
+                                <p class="text-xs text-gray-500 mt-0.5">% of base spending — typically lower in mid-retirement (less activity)</p>
+                            </div>
+                            <div class="col-span-2">
+                                <label class="block text-xs font-medium text-gray-700" for="tieredSpendingFrailMultiplier">Frail Phase Spending (%)</label>
+                                <input class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm" id="tieredSpendingFrailMultiplier" type="text" value="120" min="80" max="200" placeholder="e.g. 120">
+                                <p class="text-xs text-gray-500 mt-0.5">% of base spending — typically higher again (healthcare, assistance)</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -4782,6 +4874,10 @@
                         </th>
                         <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-help"
                             title="Liquid assets remaining at year-end after growth, withdrawal, property income, healthcare and aged care costs.">End Balance 💰
+                        </th>
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-help overseas-col"
+                            title="Annual overseas living cost (excluding return travel). Only populated in years marked with ✈. The travel component is shown separately in the Yearly Withdrawal tooltip.">
+                            Overseas 🌏
                         </th>
                         <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-help"
                             title="Total net worth: liquid assets + home equity + investment property equity. Property is shown at estimated market value less outstanding loan.">Total Net Worth 🏠

--- a/src/js/advanced-v2.js
+++ b/src/js/advanced-v2.js
@@ -347,15 +347,18 @@ function buildEngineInputs(inp) {
     // NOTE: time-bounded legal obligations (spousalMaintenanceEndsAge, youngestChildAge) are not yet
     // enforced per-year — they run for the full carerYearsExpected window. This is a known limitation.
     ...(() => {
-      const nonCarerExpense = (inp.annualParentSupport || 0)
-        + (inp.hasSpousalMaintenance ? (inp.annualSpousalMaintenance || 0) : 0)
-        + (inp.hasChildSupport ? (inp.annualChildSupport || 0) : 0);
-      const carerExpense = inp.isCarer ? (inp.carerAnnualExpense || 0) : 0;
-      const totalFamilyExpense = carerExpense + nonCarerExpense;
+      // Use nullish coalescing so explicit carerAnnualExpense=0 is preserved and
+      // annualParentSupport only acts as a fallback when carerAnnualExpense is unset.
+      const parentCareExpense = inp.isCarer
+        ? (inp.carerAnnualExpense ?? inp.annualParentSupport ?? 0)
+        : (inp.annualParentSupport || 0);
+      const spousalExpense = inp.hasSpousalMaintenance ? (inp.annualSpousalMaintenance || 0) : 0;
+      const childSupportExpense = inp.hasChildSupport ? (inp.annualChildSupport || 0) : 0;
+      const totalFamilyExpense = parentCareExpense + spousalExpense + childSupportExpense;
       return {
-        isCarerForParents: inp.isCarer || nonCarerExpense > 0,
+        isCarerForParents: !!(inp.isCarer || (inp.annualParentSupport || 0) > 0),
         carerReducedWorkPercent: inp.isCarer ? pct(inp.carerReducedWorkPercent) : 0,
-        carerYearsExpected: inp.isCarer ? (inp.carerYearsExpected || 0) : (nonCarerExpense > 0 ? 999 : 0),
+        carerYearsExpected: inp.isCarer ? (inp.carerYearsExpected || 0) : ((inp.annualParentSupport || 0) > 0 ? 999 : 0),
         carerAnnualExpense: totalFamilyExpense,
       };
     })(),
@@ -383,6 +386,21 @@ function buildEngineInputs(inp) {
     overseasStartAge: inp.goingOverseas ? (inp.ageMovingOverseas || 0) : 0,
     overseasAnnualBudget: inp.goingOverseas ? (inp.annualLivingCostOverseas || 0) : 0,
     overseasReturnFrequency: inp.returnFrequency || 'never',
+    overseasMoveType: inp.overseasMoveType || 'permanent',
+    overseasTaxResidency: inp.overseasTaxResidency || 'australian',
+    overseasHealthCover: inp.overseasHealthCover || 'international_private',
+    maintainResidency: Boolean(inp.maintainResidency),
+    overseasPropertyStrategy: inp.propertyStrategy || 'keep-personal',
+    overseasTrustBeneficiaries: inp.trustBeneficiaries || 'you-only',
+    overseasSuperAccessStrategy: inp.superAccess || 'pension-mode',
+    overseasAgreementCountry: Boolean(inp.overseasAgreementCountry),
+    overseasFallbackAge: inp.overseasFallbackAge || 0,
+    overseasFallbackTrigger: inp.overseasFallbackTrigger || 'none',
+    overseasSpendingCurrency: inp.overseasSpendingCurrency || 'AUD',
+    overseasAudFxChange: pct(inp.overseasAudFxChange !== undefined ? inp.overseasAudFxChange : -1, -1),
+    overseasHousingType: inp.overseasHousingType || 'rent',
+    overseasAnnualRent: inp.overseasAnnualRent || 0,
+    overseasDestination: inp.destination || '',
 
     creditCardBalance: inp.ccBalance,
     creditCardRate: pct(inp.ccRate || 20, 20),
@@ -391,6 +409,22 @@ function buildEngineInputs(inp) {
     carLoanBalance: inp.carLoan,
     carLoanRate: pct(inp.carLoanRate || 8, 8),
     hecsBalance: inp.hecsBalance,
+
+    // Age-related optional costs
+    enableHomeModifications: Boolean(inp.enableHomeModifications),
+    homeModificationCost: inp.homeModificationCost || 0,
+    homeModificationAge: inp.homeModificationAge || 78,
+    homeModificationRecurring: inp.homeModificationRecurring || 0,
+    enableAnnuity: Boolean(inp.enableAnnuity),
+    annuityPurchaseAge: inp.annuityPurchaseAge || 67,
+    annuityLumpSum: inp.annuityLumpSum || 0,
+    annuityAnnualIncome: inp.annuityAnnualIncome || 0,
+    enableTieredSpending: Boolean(inp.enableTieredSpending),
+    tieredSpendingActiveAge: inp.tieredSpendingActiveAge || 75,
+    tieredSpendingFrailAge: inp.tieredSpendingFrailAge || 85,
+    tieredSpendingActiveMultiplier: pct(inp.tieredSpendingActiveMultiplier || 110, 110),
+    tieredSpendingStableMultiplier: pct(inp.tieredSpendingStableMultiplier || 90, 90),
+    tieredSpendingFrailMultiplier: pct(inp.tieredSpendingFrailMultiplier || 115, 115),
   };
 }
 
@@ -817,6 +851,22 @@ function readInputs() {
     agedCareStartAge: num('agedCareStartAge'),
     agedCareAnnualCost: num('agedCareAnnualCost'),
 
+    // Age-related optional costs (Section 13)
+    enableHomeModifications: chk('enableHomeModifications'),
+    homeModificationCost: num('homeModificationCost', 25000),
+    homeModificationAge: num('homeModificationAge', 78),
+    homeModificationRecurring: num('homeModificationRecurring', 2000),
+    enableAnnuity: chk('enableAnnuity'),
+    annuityPurchaseAge: num('annuityPurchaseAge', 67),
+    annuityLumpSum: num('annuityLumpSum', 200000),
+    annuityAnnualIncome: num('annuityAnnualIncome', 14000),
+    enableTieredSpending: chk('enableTieredSpending'),
+    tieredSpendingActiveAge: num('tieredSpendingActiveAge', 75),
+    tieredSpendingFrailAge: num('tieredSpendingFrailAge', 85),
+    tieredSpendingActiveMultiplier: num('tieredSpendingActiveMultiplier', 110),
+    tieredSpendingStableMultiplier: num('tieredSpendingStableMultiplier', 90),
+    tieredSpendingFrailMultiplier: num('tieredSpendingFrailMultiplier', 115),
+
     // Markets
     inflation: num('inflation', 2.6),
     invReturn: num('invReturn', 6.5),
@@ -975,6 +1025,10 @@ function buildExportAppBridge() {
     currentRiskProfile: APP_STATE.riskProfile,
     currentAllocationStrategy: APP_STATE.allocationStrategy,
     currentOverseasData: APP_STATE.overseasExportData,
+    // Plain-English narrative text for PDF
+    plainEnglishNarrative: APP_STATE.adaptedResult && APP_STATE.input
+      ? buildPlainEnglishNarrativeText(APP_STATE.adaptedResult, APP_STATE.input, APP_STATE.monteCarloResults)
+      : null,
   };
 }
 
@@ -1204,6 +1258,43 @@ function normalizeImportedUserData(userData = {}) {
     hasChildSupport: Boolean(userData.hasChildSupport ?? base.hasChildSupport),
     annualChildSupport: userData.annualChildSupport ?? base.annualChildSupport,
     youngestChildAge: userData.youngestChildAge ?? base.youngestChildAge,
+    // Overseas retirement — map classic advanced.html field names → v2 field names.
+    // This ensures a JSON saved on either page loads correctly on the other.
+    goingOverseas: userData.goingOverseas ?? (userData.overseasCountry ? userData.overseasCountry !== '' : base.goingOverseas),
+    destination: userData.destination ?? userData.overseasCountry ?? base.destination,
+    ageMovingOverseas: userData.ageMovingOverseas ?? userData.overseasAge ?? userData.overseasStartAge ?? base.ageMovingOverseas,
+    annualLivingCostOverseas: userData.annualLivingCostOverseas ?? userData.estimatedLivingCosts ?? userData.overseasAnnualBudget ?? base.annualLivingCostOverseas,
+    returnFrequency: userData.returnFrequency ?? userData.overseasReturnFrequency ?? base.returnFrequency,
+    overseasMoveType: userData.overseasMoveType ?? base.overseasMoveType,
+    overseasTaxResidency: userData.overseasTaxResidency ?? base.overseasTaxResidency,
+    overseasHealthCover: userData.overseasHealthCover ?? base.overseasHealthCover,
+    maintainResidency: Boolean(userData.maintainResidency ?? base.maintainResidency),
+    overseasAgreementCountry: Boolean(userData.overseasAgreementCountry ?? base.overseasAgreementCountry),
+    propertyStrategy: userData.propertyStrategy ?? base.propertyStrategy,
+    trustBeneficiaries: userData.trustBeneficiaries ?? base.trustBeneficiaries,
+    superAccess: userData.superAccess ?? base.superAccess,
+    overseasSpendingCurrency: userData.overseasSpendingCurrency ?? base.overseasSpendingCurrency,
+    overseasAudFxChange: userData.overseasAudFxChange ?? base.overseasAudFxChange,
+    overseasHousingType: userData.overseasHousingType ?? base.overseasHousingType,
+    overseasAnnualRent: userData.overseasAnnualRent ?? base.overseasAnnualRent,
+    overseasFallbackAge: userData.overseasFallbackAge ?? base.overseasFallbackAge,
+    overseasFallbackTrigger: userData.overseasFallbackTrigger ?? base.overseasFallbackTrigger,
+    australianResidenceYears: userData.australianResidenceYears ?? base.australianResidenceYears,
+    // Age-related optional costs (Section 13)
+    enableHomeModifications: Boolean(userData.enableHomeModifications ?? base.enableHomeModifications),
+    homeModificationCost: userData.homeModificationCost ?? base.homeModificationCost,
+    homeModificationAge: userData.homeModificationAge ?? base.homeModificationAge,
+    homeModificationRecurring: userData.homeModificationRecurring ?? base.homeModificationRecurring,
+    enableAnnuity: Boolean(userData.enableAnnuity ?? base.enableAnnuity),
+    annuityPurchaseAge: userData.annuityPurchaseAge ?? base.annuityPurchaseAge,
+    annuityLumpSum: userData.annuityLumpSum ?? base.annuityLumpSum,
+    annuityAnnualIncome: userData.annuityAnnualIncome ?? base.annuityAnnualIncome,
+    enableTieredSpending: Boolean(userData.enableTieredSpending ?? base.enableTieredSpending),
+    tieredSpendingActiveAge: userData.tieredSpendingActiveAge ?? base.tieredSpendingActiveAge,
+    tieredSpendingFrailAge: userData.tieredSpendingFrailAge ?? base.tieredSpendingFrailAge,
+    tieredSpendingActiveMultiplier: userData.tieredSpendingActiveMultiplier ?? base.tieredSpendingActiveMultiplier,
+    tieredSpendingStableMultiplier: userData.tieredSpendingStableMultiplier ?? base.tieredSpendingStableMultiplier,
+    tieredSpendingFrailMultiplier: userData.tieredSpendingFrailMultiplier ?? base.tieredSpendingFrailMultiplier,
   };
 }
 
@@ -1261,6 +1352,7 @@ function buildOverseasAnalyzer(baseState) {
           ? Math.max(0, baseState.input.retireAge - baseState.input.ageCameToAU)
           : Math.max(0, baseState.input.retireAge - 16),
       enableProposedBudget2026: baseState.input.budget2627,
+      overseasTaxResidency: baseState.input.overseasTaxResidency || 'australian',
     },
     {
       superBalance: baseState.input.superBal + (baseState.engineInputs?.isCouple ? baseState.input.partnerSuperBal : 0),
@@ -1282,12 +1374,17 @@ function buildOverseasExportData(analysis, annualBudget, finalBalance) {
     ? Math.round(((annualCost - australiaAnnual) / australiaAnnual) * 100)
     : 0;
   const availableAnnualIncome = (APP_STATE.adaptedResult?.monthlyPaycheck || 0) * 12;
+  const input = APP_STATE.input || {};
 
   return {
     config: {
       destinationCountry: analysis.country,
       currency: 'AUD',
       monthlyBudget,
+      moveType: input.overseasMoveType || 'unknown',
+      taxResidency: input.overseasTaxResidency || 'unknown',
+      returnFrequency: input.returnFrequency || 'unknown',
+      ageMovingOverseas: input.ageMovingOverseas || null,
     },
     scenarios: [
       {
@@ -1300,6 +1397,12 @@ function buildOverseasExportData(analysis, annualBudget, finalBalance) {
         availableAnnualIncome,
       },
     ],
+    pensionPortability: analysis.agePensionPortability || null,
+    taxImplications: analysis.taxImplications || null,
+    healthcare: analysis.healthcare || null,
+    riskAssessment: analysis.riskAssessment || null,
+    recommendations: analysis.recommendations || null,
+    overview: analysis.overview || null,
   };
 }
 
@@ -1668,6 +1771,192 @@ function buildCareerImpactBlock(inp) {
     </div>`;
 }
 
+/**
+ * Build a plain-text (no HTML) version of the narrative for PDF export.
+ */
+function buildPlainEnglishNarrativeText(adaptedResult, inp, mc) {
+  if (!adaptedResult || !inp?.age) return null;
+
+  const lastsUntil = adaptedResult.lastsUntil;
+  const lifespan = inp.lifespan || 90;
+  const monthlyPaycheck = adaptedResult.monthlyPaycheck || 0;
+  const asfaMonthly = (inp.household === 'couple') ? 5900 : 4080;
+  const asfaLabel = (inp.household === 'couple') ? 'ASFA comfortable couple' : 'ASFA comfortable single';
+
+  const paycheckVsAsfa = monthlyPaycheck >= asfaMonthly
+    ? `Your monthly retirement paycheck of ${fmt$(monthlyPaycheck)} meets the ${asfaLabel} standard of ${fmt$(asfaMonthly)}/month.`
+    : `Your monthly retirement paycheck of ${fmt$(monthlyPaycheck)} is below the ${asfaLabel} standard of ${fmt$(asfaMonthly)}/month — consider increasing savings.`;
+
+  let fundingLine;
+  if (!lastsUntil || lastsUntil === 0) {
+    fundingLine = 'Your funds are projected to run out before retirement — urgent action needed.';
+  } else if (lastsUntil >= lifespan) {
+    fundingLine = `Your retirement savings are projected to cover your full planned lifespan to age ${lifespan}.`;
+  } else {
+    const shortfall = lifespan - lastsUntil;
+    fundingLine = `Your funds are projected to last until age ${lastsUntil}, which is ${shortfall} year${shortfall !== 1 ? 's' : ''} short of your planned lifespan (${lifespan}).`;
+  }
+
+  let topRisk = 'longevity';
+  if (inp.healthCondition === 'poor' || inp.healthCondition === 'fair') topRisk = 'healthcare costs';
+  else if (mc && (mc.successRate || 0) < 0.7) topRisk = 'investment sequence of returns';
+  else if ((inp.inflation || 2.6) > 3.5) topRisk = 'high inflation';
+  else if (lastsUntil && lastsUntil < lifespan) topRisk = 'insufficient savings rate';
+
+  return `${fundingLine} ${paycheckVsAsfa} Your biggest risk factor is ${topRisk}. Use the AI Recommendations section for prioritised actions to strengthen your plan.`;
+}
+
+/**
+ * Build a plain-English narrative summary of the retirement plan.
+ * Surfaces the most important outcomes in 2–3 readable sentences.
+ */
+function buildPlainEnglishNarrative(adaptedResult, inp, mc) {
+  if (!adaptedResult || !inp?.age) return '';
+
+  const lastsUntil = adaptedResult.lastsUntil;
+  const lifespan = inp.lifespan || 90;
+  const retireAge = inp.retireAge || 65;
+  const monthlyPaycheck = adaptedResult.monthlyPaycheck || 0;
+  // ASFA comfortable 2025: $5,900/month couple, $4,080/month single
+  const asfaMonthly = (inp.household === 'couple') ? 5900 : 4080;
+  const asfaLabel = (inp.household === 'couple') ? 'ASFA comfortable couple' : 'ASFA comfortable single';
+  const paycheckVsAsfa = monthlyPaycheck >= asfaMonthly
+    ? `your monthly retirement paycheck of ${fmt$(monthlyPaycheck)} <b>meets</b> the ${asfaLabel} standard of ${fmt$(asfaMonthly)}/month`
+    : `your monthly retirement paycheck of ${fmt$(monthlyPaycheck)} is <b>below</b> the ${asfaLabel} standard of ${fmt$(asfaMonthly)}/month — you may need to adjust your target income or savings rate`;
+
+  let fundingLine;
+  if (!lastsUntil || lastsUntil === 0) {
+    fundingLine = 'Your funds are projected to <b>run out before retirement</b> — urgent action needed.';
+  } else if (lastsUntil >= lifespan) {
+    fundingLine = `Your retirement savings are projected to <b>cover your full planned lifespan to age ${lifespan}</b>.`;
+  } else {
+    const shortfall = lifespan - lastsUntil;
+    fundingLine = `Your funds are projected to last until age <b>${lastsUntil}</b>, which is <b>${shortfall} year${shortfall !== 1 ? 's' : ''} short</b> of your planned lifespan (${lifespan}).`;
+  }
+
+  // Identify the top risk
+  let topRisk = 'longevity';
+  if (inp.healthCondition === 'poor' || inp.healthCondition === 'fair') topRisk = 'healthcare costs';
+  else if (mc && (mc.successRate || 0) < 0.7) topRisk = 'investment sequence of returns';
+  else if ((inp.inflation || 2.6) > 3.5) topRisk = 'high inflation';
+  else if (lastsUntil && lastsUntil < lifespan) topRisk = 'insufficient savings rate';
+
+  const riskLine = `Your biggest risk factor is <b>${topRisk}</b>.`;
+
+  // Downsize extension hint
+  const downsizeLine = (inp.downsizePlan === 'yes' && adaptedResult.superAtRetire > 0)
+    ? ' Proceeding with your planned downsize will provide a lump-sum injection \u2014 revisit the Year-by-Year table after it is modelled.'
+    : '';
+
+  return `
+    <div class="summary-chart" style="grid-column:1/-1;background:linear-gradient(135deg,var(--surface) 0%,color-mix(in srgb,var(--accent) 6%,var(--surface)) 100%);border:1.5px solid color-mix(in srgb,var(--accent) 25%,var(--border))">
+      <h5 style="color:var(--accent)">📖 Plain-English Summary</h5>
+      <p style="margin:0 0 10px;line-height:1.7;font-size:14px">${fundingLine} Based on your inputs, ${paycheckVsAsfa}.${downsizeLine}</p>
+      <p style="margin:0;line-height:1.7;font-size:14px;color:var(--ink-2)">${riskLine} Use the <b>AI Recommendations</b> tab for prioritised actions to strengthen your plan.</p>
+    </div>`;
+}
+
+/**
+ * Build the "Retirement Target Builder" card — shows what income the user will
+ * actually need in retirement by subtracting one-off pre-retirement costs from
+ * their current spending.
+ */
+function buildRetirementTargetBuilder(inp) {
+  if (!inp?.age) return '';
+
+  const currentSpending = (inp.desiredIncome || 0);
+  if (currentSpending <= 0) return '';
+
+  // Mortgage costs that end at retirement
+  const annualMortgage = inp.mortgage > 0
+    ? Math.min(currentSpending * 0.25, (inp.mortgage * pct(inp.mortgageRate || 5, 5) * 1.1))
+    : 0;
+
+  // Children / education costs that end when youngest child finishes uni (est. age 22)
+  const childrenCosts = inp.dependents > 0
+    ? Math.min(currentSpending * 0.15,
+        inp.dependents * ((inp.educationCostPerChild || 0) / Math.max(1, (22 - (inp.youngestChildAge || 10)))))
+    : 0;
+
+  // Healthcare premium uplift in retirement (healthcare tends to grow faster than general inflation)
+  const hcUplift = (inp.hasPrivateHospital ? 2500 : 0) + (inp.healthCondition === 'fair' ? 3000 : 0) + (inp.healthCondition === 'poor' ? 6000 : 0);
+
+  const estimatedRetirementNeed = Math.max(0, currentSpending - annualMortgage - childrenCosts + hcUplift);
+  const monthly = Math.round(estimatedRetirementNeed / 12);
+  const asfaComfortable = (inp.household === 'couple') ? 70800 : 48960;
+  const gap = estimatedRetirementNeed - (inp.desiredIncome || 0);
+
+  const rows = [
+    { label: 'Your target retirement income', val: fmt$(currentSpending) + '/yr', note: 'As entered' },
+    annualMortgage > 0 ? { label: '− Mortgage payments (end at retirement)', val: `−${fmt$(Math.round(annualMortgage))}/yr`, note: 'Freed up' } : null,
+    childrenCosts > 0 ? { label: '− Children / education costs', val: `−${fmt$(Math.round(childrenCosts))}/yr`, note: 'Freed up' } : null,
+    hcUplift > 0 ? { label: '+ Healthcare premium uplift', val: `+${fmt$(hcUplift)}/yr`, note: 'Retirement health costs tend to rise faster than CPI' } : null,
+    { label: '= Estimated lifestyle need in retirement', val: `<b>${fmt$(Math.round(estimatedRetirementNeed))}/yr</b>`, note: `${fmt$(monthly)}/month`, bold: true },
+    { label: 'ASFA comfortable standard (2025)', val: fmt$(asfaComfortable) + '/yr', note: `${(inp.household === 'couple') ? 'Couple' : 'Single'} — covers a comfortable lifestyle without being extravagant` },
+  ].filter(Boolean);
+
+  return `
+    <div class="summary-chart" style="grid-column:1/-1">
+      <h5>🎯 Retirement Target Builder</h5>
+      <div class="desc">What you'll actually need in retirement — your current spending adjusted for costs that stop (mortgage, children) and costs that grow (healthcare).</div>
+      <div class="mc-results-grid" style="margin-top:12px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))">
+        ${rows.map((r) => `
+          <div class="mc-stat" style="${r.bold ? 'background:color-mix(in srgb,var(--accent) 8%,var(--surface));border:1px solid color-mix(in srgb,var(--accent) 20%,var(--border))' : ''}">
+            <div class="mc-k">${r.label}</div>
+            <div class="mc-v" style="${r.bold ? 'color:var(--accent)' : ''}">${r.val}</div>
+            <div class="mc-sub">${r.note}</div>
+          </div>
+        `).join('')}
+      </div>
+      <p style="margin:10px 0 0;font-size:12px;color:var(--ink-3)">These adjustments are indicative only. Actual retirement costs vary by health, lifestyle, and personal circumstances.</p>
+    </div>`;
+}
+
+/**
+ * Build a Sequence of Returns Risk callout for the risk/summary panel.
+ * Uses MC results when available to estimate early-crash vs late-crash impact.
+ */
+function buildSequenceOfReturnsCallout(mc, adaptedResult, inp) {
+  if (!inp?.age || !adaptedResult) return '';
+
+  // If we have MC results, compute early crash vs late crash delta
+  // from the scenarios array (sorted: scenarios[0] = best, last = worst)
+  let earlyRiskHtml = '';
+  let lateRiskHtml = '';
+  if (mc?.scenarios?.length >= 2) {
+    const best = mc.scenarios[mc.scenarios.length - 1]?.finalBalance || 0;
+    const worst = mc.scenarios[0]?.finalBalance || 0;
+    const spread = best - worst;
+    const spreadYears = adaptedResult?.monthlyPaycheck > 0
+      ? Math.round(spread / ((adaptedResult.monthlyPaycheck * 12) || 1))
+      : 0;
+    earlyRiskHtml = `<div class="mc-stat"><div class="mc-k">🔴 Crash in Year 1 of retirement</div><div class="mc-v" style="color:var(--danger)">${fmt$(worst, { compact: true })}</div><div class="mc-sub">10th-percentile final balance</div></div>`;
+    lateRiskHtml = `<div class="mc-stat"><div class="mc-k">🟢 Strong early returns</div><div class="mc-v" style="color:var(--success)">${fmt$(best, { compact: true })}</div><div class="mc-sub">90th-percentile final balance</div></div>`;
+    if (spreadYears > 0) {
+      earlyRiskHtml += `<div class="mc-stat" style="grid-column:1/-1"><div class="mc-k">Impact spread</div><div class="mc-v">${spreadYears} years</div><div class="mc-sub">A crash in year 1 vs strong early returns can mean ${spreadYears} years' difference in portfolio longevity</div></div>`;
+    }
+  } else if (adaptedResult) {
+    const baseBalance = adaptedResult.finalBalance || 0;
+    const earlyBad = Math.round(baseBalance * 0.55); // ~45% drop scenario
+    const lateBad = Math.round(baseBalance * 0.80);  // ~20% drop scenario
+    earlyRiskHtml = `<div class="mc-stat"><div class="mc-k">🔴 Crash in Year 1 (estimated)</div><div class="mc-v" style="color:var(--danger)">${fmt$(earlyBad, { compact: true })}</div><div class="mc-sub">~45% reduction in final balance vs base case</div></div>`;
+    lateRiskHtml = `<div class="mc-stat"><div class="mc-k">🟡 Crash in Year 10 (estimated)</div><div class="mc-v" style="color:var(--warning)">${fmt$(lateBad, { compact: true })}</div><div class="mc-sub">~20% reduction in final balance vs base case</div></div>`;
+  }
+
+  if (!earlyRiskHtml) return '';
+
+  return `
+    <div class="summary-chart">
+      <h5>⚡ Sequence of Returns Risk</h5>
+      <div class="desc">When a market crash occurs matters enormously. A crash in your first year of retirement is far more damaging than one a decade later — your portfolio has less time to recover while you're still drawing from it.</div>
+      <div class="mc-results-grid" style="margin-top:10px">
+        ${earlyRiskHtml}
+        ${lateRiskHtml}
+      </div>
+      <p style="margin:10px 0 0;font-size:12px;color:var(--ink-3)">Run Monte Carlo with 5,000+ runs for a more accurate spread. Consider holding 1–2 years of income in cash as a buffer against early retirement crashes.</p>
+    </div>`;
+}
+
 function renderSummaryPanel() {
   const state = APP_STATE;
   const summaryItems = [
@@ -1755,6 +2044,9 @@ function renderSummaryPanel() {
     </div>` : '';
 
   const careerImpactBlock = buildCareerImpactBlock(inp);
+  const narrativeBlock = buildPlainEnglishNarrative(state.adaptedResult, inp, state.monteCarloResults);
+  const targetBuilderBlock = buildRetirementTargetBuilder(inp);
+  const sorBlock = buildSequenceOfReturnsCallout(state.monteCarloResults, state.adaptedResult, inp);
 
   setPanelHtml('summary', `
     <div class="summary-grid">
@@ -1772,7 +2064,10 @@ function renderSummaryPanel() {
         </div>
       </div>
       ${monteCarloBlock}
+      ${narrativeBlock}
     </div>
+    ${targetBuilderBlock}
+    ${sorBlock}
     ${recommendationLead}
     ${careerImpactBlock}
     ${assumptionsBlock}
@@ -2088,11 +2383,32 @@ async function runMonteCarloAnalysis() {
   // This is the single source of truth — avoids any double-read discrepancy between
   // the select element and the already-computed engine state.
   const runsToUse = baseState.engineInputs.numRuns || DEFAULTS.simulation.numRuns || 500;
+
+  // Wire up a progress callback so the loading overlay shows real progress for large runs.
+  const progressBarEl = document.getElementById('adv2-progress-bar');
+  const progressLabelEl = document.getElementById('adv2-loading-label');
+  const progressSubEl = document.getElementById('adv2-loading-sub');
+
+  const mcProgressCallback = runsToUse >= 500 ? async (completed, total) => {
+    const pct = Math.round((completed / total) * 100);
+    if (progressBarEl) progressBarEl.style.width = pct + '%';
+    const remaining = total - completed;
+    const approxSecs = Math.ceil((remaining / total) * (total > 5000 ? 45 : 15));
+    if (progressLabelEl) progressLabelEl.textContent = `Running… ${pct}%`;
+    if (progressSubEl) progressSubEl.textContent = `Completed ${completed.toLocaleString()} of ${total.toLocaleString()} runs${approxSecs > 2 ? ` — ~${approxSecs}s remaining` : ''}`;
+    // Yield to the browser so the progress bar updates are visible
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  } : null;
+
+  if (progressBarEl) progressBarEl.style.width = '0%';
+
   APP_STATE.monteCarloResults = await simulator.runMonteCarloSimulation(
     baseState.engineInputs,
     runsToUse,
-    null
+    mcProgressCallback
   );
+
+  if (progressBarEl) progressBarEl.style.width = '100%';
   APP_STATE.riskProfile = normaliseRiskProfile(
     riskProfiler.generateRiskProfileSummary(baseState.engineInputs, APP_STATE.monteCarloResults)
   );
@@ -2779,6 +3095,9 @@ function boot() {
     bindConditional('enableShocks', 'data-shocks');
     bindConditional('hasSpousalMaintenance', 'data-spousal');
     bindConditional('hasChildSupport', 'data-childsupport');
+    bindConditional('enableHomeModifications', 'data-home-mods');
+    bindConditional('enableAnnuity', 'data-annuity');
+    bindConditional('enableTieredSpending', 'data-tiered-spending');
 
     // Monte Carlo custom runs show/hide + update sidebar label
     const mcRunsSel = document.getElementById('mcRuns');
@@ -2851,6 +3170,54 @@ function boot() {
 
     bindLifespanValidation('lifespan', 'age');
     bindLifespanValidation('partnerLifespan', 'partnerAge');
+
+    // Link returnFrequency to overseasMoveType:
+    // A 'permanent' move means there are no return trips — lock frequency to 'never'.
+    (function bindOverseasMoveType() {
+      const moveTypeEl = document.getElementById('overseasMoveType');
+      const returnFreqEl = document.getElementById('returnFrequency');
+      if (!moveTypeEl || !returnFreqEl) return;
+
+      function syncReturnFrequency() {
+        if (moveTypeEl.value === 'permanent') {
+          returnFreqEl.value = 'never';
+          returnFreqEl.disabled = true;
+          returnFreqEl.title = 'Return visits disabled for a permanent move';
+        } else {
+          returnFreqEl.disabled = false;
+          returnFreqEl.title = '';
+          if (returnFreqEl.value === 'never' && moveTypeEl.value !== 'permanent') {
+            returnFreqEl.value = 'annually';
+          }
+        }
+      }
+
+      moveTypeEl.addEventListener('change', syncReturnFrequency);
+      syncReturnFrequency();
+    })();
+
+    // trustBeneficiaries should only be active when a trust structure is in use.
+    (function bindTrustBeneficiaries() {
+      const propertyStratEl = document.getElementById('propertyStrategy');
+      const hasTrustEl = document.getElementById('hasTrust');
+      const benefRow = document.getElementById('trustBeneficiaries')?.closest('.field');
+      if (!benefRow) return;
+
+      function syncTrustBeneficiaries() {
+        const usingTrust = (propertyStratEl?.value === 'transfer-trust') || Boolean(hasTrustEl?.checked);
+        benefRow.style.opacity = usingTrust ? '' : '0.35';
+        benefRow.title = usingTrust ? '' : 'Enable a trust structure above to configure beneficiaries';
+        const sel = document.getElementById('trustBeneficiaries');
+        if (sel) sel.disabled = !usingTrust;
+      }
+
+      if (propertyStratEl) propertyStratEl.addEventListener('change', syncTrustBeneficiaries);
+      if (hasTrustEl) {
+        hasTrustEl.addEventListener('change', syncTrustBeneficiaries);
+        hasTrustEl.addEventListener('input', syncTrustBeneficiaries);
+      }
+      syncTrustBeneficiaries();
+    })();
 
     // Auto-fill spending currency when overseas destination changes
     (function bindDestinationCurrency() {

--- a/src/js/advanced-v2.js
+++ b/src/js/advanced-v2.js
@@ -1884,8 +1884,6 @@ function buildRetirementTargetBuilder(inp) {
   const estimatedRetirementNeed = Math.max(0, currentSpending - annualMortgage - childrenCosts + hcUplift);
   const monthly = Math.round(estimatedRetirementNeed / 12);
   const asfaComfortable = (inp.household === 'couple') ? 70800 : 48960;
-  const gap = estimatedRetirementNeed - (inp.desiredIncome || 0);
-
   const rows = [
     { label: 'Your target retirement income', val: fmt$(currentSpending) + '/yr', note: 'As entered' },
     annualMortgage > 0 ? { label: '− Mortgage payments (end at retirement)', val: `−${fmt$(Math.round(annualMortgage))}/yr`, note: 'Freed up' } : null,
@@ -1920,12 +1918,14 @@ function buildSequenceOfReturnsCallout(mc, adaptedResult, inp) {
   if (!inp?.age || !adaptedResult) return '';
 
   // If we have MC results, compute early crash vs late crash delta
-  // from the scenarios array (sorted: scenarios[0] = best, last = worst)
+  // using available percentile outputs.
   let earlyRiskHtml = '';
   let lateRiskHtml = '';
-  if (mc?.scenarios?.length >= 2) {
-    const best = mc.scenarios[mc.scenarios.length - 1]?.finalBalance || 0;
-    const worst = mc.scenarios[0]?.finalBalance || 0;
+  const mcWorst = mc?.percentiles?.p10 ?? mc?.percentile10;
+  const mcBest = mc?.percentiles?.p90 ?? mc?.percentile90;
+  if (mcWorst != null && mcBest != null) {
+    const best = mcBest || 0;
+    const worst = mcWorst || 0;
     const spread = best - worst;
     const spreadYears = adaptedResult?.monthlyPaycheck > 0
       ? Math.round(spread / ((adaptedResult.monthlyPaycheck * 12) || 1))

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -870,7 +870,10 @@ class RetirementCalculatorApp {
             trustBeneficiaries: safeGetSelectValue('trustBeneficiaries', 'you-only'),
             superAccess: safeGetSelectValue('superAccess', 'pension-mode'),
             overseasSpendingCurrency: safeGetSelectValue('overseasSpendingCurrency', 'AUD'),
-            overseasAudFxChange: parseFloat(safeGetValue('overseasAudFxChange', '-1')) || -1,
+            overseasAudFxChange: (() => {
+                const fxChange = parseFloat(safeGetValue('overseasAudFxChange', '-1'));
+                return Number.isNaN(fxChange) ? -1 : fxChange;
+            })(),
             overseasHousingType: safeGetSelectValue('overseasHousingType', 'rent'),
             overseasAnnualRent: parseFormattedNumber(getRawValue('overseasAnnualRent', '0')),
             overseasFallbackAge: parseInt(safeGetValue('overseasFallbackAge', 0)) || 0,

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -664,6 +664,22 @@ class RetirementCalculatorApp {
             agedCareDuration: safeGetValue('agedCareDuration', config.healthcare.agedCareDuration),
             agedCareAnnualCost: safeGetValue('agedCareAnnualCost', config.healthcare.agedCareAnnualCost),
 
+            // Age-related optional costs (mirrors advanced-v2.html Section 13)
+            enableHomeModifications: safeGetChecked('enableHomeModifications', false),
+            homeModificationCost: safeGetValue('homeModificationCost', 25000),
+            homeModificationAge: safeGetValue('homeModificationAge', 75),
+            homeModificationRecurring: safeGetValue('homeModificationRecurring', 2000),
+            enableAnnuity: safeGetChecked('enableAnnuity', false),
+            annuityPurchaseAge: safeGetValue('annuityPurchaseAge', 67),
+            annuityLumpSum: safeGetValue('annuityLumpSum', 200000),
+            annuityAnnualIncome: safeGetValue('annuityAnnualIncome', 12000),
+            enableTieredSpending: safeGetChecked('enableTieredSpending', false),
+            tieredSpendingActiveAge: safeGetValue('tieredSpendingActiveAge', 75),
+            tieredSpendingFrailAge: safeGetValue('tieredSpendingFrailAge', 85),
+            tieredSpendingActiveMultiplier: safeGetValue('tieredSpendingActiveMultiplier', 110) / 100,
+            tieredSpendingStableMultiplier: safeGetValue('tieredSpendingStableMultiplier', 90) / 100,
+            tieredSpendingFrailMultiplier: safeGetValue('tieredSpendingFrailMultiplier', 120) / 100,
+
             // Economic assumptions
             inflation: safeGetValue('inflation', config.economic.inflation) / 100,
             investmentReturn: safeGetValue('investmentReturn', config.economic.investmentReturn) / 100,
@@ -833,13 +849,32 @@ class RetirementCalculatorApp {
             // These measures are NOT yet passed by Parliament.
             enableProposedBudget2026: safeGetChecked('enableProposedBudget2026', false),
 
-            // Overseas retirement — wire the Overseas tab fields into the simulator
-            // so the Year-by-Year projection uses the overseas living budget from
-            // the specified departure age instead of the domestic ASFA target.
+            // Overseas retirement — wire ALL Overseas tab fields into the simulator.
+            // goingOverseas is derived from whether a destination country has been chosen.
             goingOverseas: safeGetSelectValue('overseasCountry', '') !== '',
+            // classic field names — also saved under v2-compatible aliases below
+            overseasCountry: safeGetSelectValue('overseasCountry', ''),
+            overseasAge: parseInt(safeGetValue('overseasAge', 0)) || 0,
+            estimatedLivingCosts: parseFormattedNumber(getRawValue('estimatedLivingCosts', '0')),
+            // engine-facing aliases (match advanced-v2.js field names for cross-compatibility)
             overseasStartAge: parseInt(safeGetValue('overseasAge', 0)) || 0,
             overseasAnnualBudget: parseFormattedNumber(getRawValue('estimatedLivingCosts', '0')),
-            overseasReturnFrequency: safeGetSelectValue('returnFrequency', 'annually')
+            overseasReturnFrequency: safeGetSelectValue('returnFrequency', 'annually'),
+            returnFrequency: safeGetSelectValue('returnFrequency', 'annually'),
+            overseasMoveType: safeGetSelectValue('overseasMoveType', 'permanent'),
+            overseasTaxResidency: safeGetSelectValue('overseasTaxResidency', 'australian'),
+            overseasHealthCover: safeGetSelectValue('overseasHealthCover', 'international_private'),
+            maintainResidency: safeGetChecked('maintainResidency', false),
+            overseasAgreementCountry: safeGetChecked('overseasAgreementCountry', false),
+            propertyStrategy: safeGetSelectValue('propertyStrategy', 'keep-personal'),
+            trustBeneficiaries: safeGetSelectValue('trustBeneficiaries', 'you-only'),
+            superAccess: safeGetSelectValue('superAccess', 'pension-mode'),
+            overseasSpendingCurrency: safeGetSelectValue('overseasSpendingCurrency', 'AUD'),
+            overseasAudFxChange: parseFloat(safeGetValue('overseasAudFxChange', '-1')) || -1,
+            overseasHousingType: safeGetSelectValue('overseasHousingType', 'rent'),
+            overseasAnnualRent: parseFormattedNumber(getRawValue('overseasAnnualRent', '0')),
+            overseasFallbackAge: parseInt(safeGetValue('overseasFallbackAge', 0)) || 0,
+            overseasFallbackTrigger: safeGetSelectValue('overseasFallbackTrigger', 'none')
         };
 
         if (inputs.useGlidePath) {
@@ -2177,7 +2212,7 @@ class RetirementCalculatorApp {
             if (data.depleted) {
                 projectionTable.innerHTML += `
                     <tr class="bg-red-100">
-                        <td colspan="11" class="px-4 py-2 text-center font-bold text-red-800" style="font-family:var(--font-ui,'DM Sans',sans-serif)">
+                        <td colspan="12" class="px-4 py-2 text-center font-bold text-red-800" style="font-family:var(--font-ui,'DM Sans',sans-serif)">
                             ⚠️ Modelled assets depleted in ${data.year} at age ${data.age}${data.partnerAlive ? ` (partner age ${data.partnerAge})` : ''}${data.pensionIncome > 0 ? ` — projected ${data.partnerAlive ? 'combined ' : ''}Age Pension ${formatCurrency(data.pensionIncome)}/year` : ' — no Age Pension projected at that point'}
                         </td>
                     </tr>
@@ -2215,6 +2250,9 @@ class RetirementCalculatorApp {
             const withdrawTip = isOverseas
                 ? `Overseas living: ${formatCurrency(livingCost)} + Return travel: ${formatCurrency(travelCost)}. Source: ${srcLabel || '—'}.`
                 : `Annual portfolio withdrawal. Source: ${srcLabel || '—'}.`;
+            const overseasCellContent = isOverseas
+                ? `${formatCurrency(livingCost)}${travelCost > 0 ? `<span class="wy-src src-overseas" title="Return travel">+${formatCurrency(travelCost)} ✈</span>` : ''}`
+                : '<span style="color:#9ca3af">—</span>';
 
             projectionTable.innerHTML += `
                 <tr class="${rowClass}">
@@ -2228,6 +2266,7 @@ class RetirementCalculatorApp {
                     <td class="px-4 py-2 num negative">-${formatCurrency(data.healthcareCost)}</td>
                     <td class="px-4 py-2 num negative">-${formatCurrency(data.agedCareCost)}</td>
                     <td class="px-4 py-2 num ${endBal < 0 ? 'negative' : ''}" style="font-weight:600">${formatCurrency(endBal)}</td>
+                    <td class="px-4 py-2 num overseas-col${isOverseas ? ' teal' : ''}">${overseasCellContent}</td>
                     <td class="px-4 py-2 num" style="font-weight:600;color:#6D28D9">${formatCurrency(netWorth)}</td>
                 </tr>
             `;
@@ -11497,6 +11536,20 @@ document.addEventListener('DOMContentLoaded', () => {
         ipTypeSel.addEventListener('change', onTypeChange);
         onTypeChange(); // apply on page load
     }());
+
+    // Age-related optional cost section toggles (Home Modifications, Annuity, Tiered Spending)
+    [
+        { checkboxId: 'enableHomeModifications', fieldsId: 'homeModsFields' },
+        { checkboxId: 'enableAnnuity', fieldsId: 'annuityFields' },
+        { checkboxId: 'enableTieredSpending', fieldsId: 'tieredSpendingFields' },
+    ].forEach(({ checkboxId, fieldsId }) => {
+        const cb = document.getElementById(checkboxId);
+        const fields = document.getElementById(fieldsId);
+        if (!cb || !fields) return;
+        function toggle() { fields.style.display = cb.checked ? '' : 'none'; }
+        cb.addEventListener('change', toggle);
+        toggle();
+    });
 });
 
 export default RetirementCalculatorApp;

--- a/src/js/enhanced-monte-carlo.js
+++ b/src/js/enhanced-monte-carlo.js
@@ -309,8 +309,14 @@ export class EnhancedMonteCarloEngine {
                 stressTestResults.push(stressResult);
             }
 
-            if (progressCallback && i % 100 === 0) {
+            // Report progress every 50 iterations. The await ensures the browser
+            // can paint the updated progress bar and avoids freezing the UI thread
+            // for large run counts (>5,000).
+            if (progressCallback && i % 50 === 0) {
                 await progressCallback(i, runs);
+            } else if (i % 50 === 0 && runs > 1000) {
+                // Even without a callback, yield to keep the UI responsive for large runs
+                await new Promise((resolve) => setTimeout(resolve, 0));
             }
         }
 

--- a/src/js/field-tooltips.js
+++ b/src/js/field-tooltips.js
@@ -614,6 +614,81 @@ const FIELD_TOOLTIP_DEFINITIONS = {
         title: 'Likely return trigger',
         body: 'This captures the event most likely to bring you back to Australia so fallback recommendations reflect a realistic contingency.',
     },
+    // ── Age-Related Optional Costs ───────────────────────────────────────────
+    enableHomeModifications: {
+        title: 'Home modifications',
+        body: 'Enable to model a one-off accessibility spend (ramps, grab rails, bathroom refit) and optional recurring maintenance at a chosen age.',
+    },
+    homeModificationCost: {
+        title: 'One-off modification cost',
+        body: 'Lump-sum amount spent adapting your home for mobility or safety at the target age. This is drawn from accumulated assets in that year.',
+    },
+    homeModificationAge: {
+        title: 'Age to apply modification cost',
+        body: 'The year-of-age when the one-off home modification expense is deducted from your balance. Typically 75–80 when mobility needs often emerge.',
+    },
+    homeModificationRecurring: {
+        title: 'Annual recurring cost after modifications',
+        body: 'Ongoing maintenance or strata fees following the modification. Applied every year from the modification age to end of plan.',
+    },
+    enableAnnuity: {
+        title: 'Lifetime annuity / longevity insurance',
+        body: 'Model the purchase of a guaranteed income stream at a specific age to protect against outliving your super. The lump sum is deducted once; the annual income flows in thereafter.',
+    },
+    annuityPurchaseAge: {
+        title: 'Annuity purchase age',
+        body: 'The age at which you exchange a lump sum for a guaranteed income stream. Typically age 75–80 when longevity uncertainty becomes more pressing.',
+    },
+    annuityLumpSum: {
+        title: 'Annuity purchase price',
+        body: 'The single premium paid to the insurer in the purchase year. This is deducted from your balance in that year.',
+    },
+    annuityAnnualIncome: {
+        title: 'Annual annuity income',
+        body: 'The guaranteed income received each year from the annuity. This is added to pension and other income to reduce super drawdown.',
+    },
+    enableTieredSpending: {
+        title: 'Tiered retirement spending',
+        body: 'Research shows spending follows an Active → Stable → Frail curve. Enable to apply custom multipliers for each stage so the model reflects real spending behaviour.',
+    },
+    tieredSpendingActiveMultiplier: {
+        title: 'Active stage spending multiplier',
+        body: 'Spending in the early active years as a proportion of your target income. Values above 1.0 mean higher spending; below 1.0 means lower.',
+        example: '1.10 = 10% more than target income',
+    },
+    tieredSpendingActiveAge: {
+        title: 'Active stage end age',
+        body: 'The age at which the active high-spending phase transitions to the stable middle phase. Research typically places this around age 72–78.',
+    },
+    tieredSpendingStableMultiplier: {
+        title: 'Stable stage spending multiplier',
+        body: 'Spending in the quieter middle years as a proportion of target income. Often 0.85–0.95 as travel and social costs decline.',
+    },
+    tieredSpendingFrailAge: {
+        title: 'Frail stage start age',
+        body: 'The age at which late-life care needs drive spending back up. Research typically places this around age 82–88.',
+    },
+    tieredSpendingFrailMultiplier: {
+        title: 'Frail stage spending multiplier',
+        body: 'Spending in the high-care final years as a proportion of target income. Often 1.10–1.30 when healthcare and aged-care costs escalate.',
+    },
+    // ── Legal / Financial Obligations ────────────────────────────────────────
+    hasSpousalMaintenance: {
+        title: 'Spousal/partner maintenance',
+        body: 'Enable if you are legally required to pay ongoing maintenance to a former partner. The annual amount will be deducted from your available income.',
+    },
+    annualSpousalMaintenance: {
+        title: 'Annual spousal maintenance',
+        body: 'Court-ordered or agreed maintenance paid to a former spouse each year. This reduces your net disposable income during the payment period.',
+    },
+    hasChildSupport: {
+        title: 'Child support obligations',
+        body: 'Enable if you pay child support. The annual amount reduces your disposable income each year until obligations end.',
+    },
+    annualChildSupport: {
+        title: 'Annual child support paid',
+        body: 'Child support obligations reduce available cash flow each year. Enter the annual total; the model deducts this from income before calculating retirement savings.',
+    },
 };
 
 const ADVANCED_TOOLTIP_PAGE_SELECTOR = '#advancedCalculatorForm, .redesign-v2';

--- a/src/js/overseas-retirement.js
+++ b/src/js/overseas-retirement.js
@@ -207,36 +207,86 @@ export class OverseasRetirementAnalyzer {
      * Analyze tax implications
      */
     analyzeTaxImplications(country) {
-        return {
-            australianTaxResidency: {
-                status: 'Initially remain Australian tax resident',
-                implications: [
-                    'Taxed on worldwide income',
-                    'Can access super tax-free from age 60',
-                    'Investment income taxed at Australian rates'
-                ],
-                transitionToForeign: {
-                    when: 'After establishing permanent residence',
-                    implications: [
-                        'Only Australian-sourced income taxed in Australia',
-                        'Super withdrawals still tax-free (age 60+)',
-                        'No tax-free threshold (30% flat rate on Australian income)'
-                    ]
-                }
-            },
+        // Use the tax residency preference set by the user, falling back to 'australian'
+        const taxResidency = this.person?.overseasTaxResidency || 'australian';
+        const hasDTA = !!(country.tax?.doubleTaxAgreement);
+        const dtaSummary = country.tax?.agreementSummary || 'No formal agreement — consult a cross-border tax adviser';
+
+        const base = {
+            selectedResidency: taxResidency,
             superannuation: {
                 access: 'Can access at age 60 regardless of overseas residence',
                 taxation: 'Tax-free from age 60 (Australian tax)',
                 considerations: [
                     'Some funds may close accounts for permanent overseas residents',
                     'Currency conversion fees apply',
-                    country.tax?.superTaxation || 'Check local tax rules'
+                    country.tax?.superTaxation || 'Check local tax rules for super withdrawals'
                 ]
             },
             doubleTaxAgreement: {
-                exists: country.tax?.doubleTaxAgreement || false,
+                exists: hasDTA,
                 nhrScheme: country.tax?.nhrScheme || null,
-                summary: country.tax?.agreementSummary || 'Consult tax adviser'
+                summary: dtaSummary
+            }
+        };
+
+        if (taxResidency === 'foreign') {
+            return {
+                ...base,
+                australianTaxResidency: {
+                    status: 'Foreign tax resident of Australia',
+                    implications: [
+                        'Only Australian-sourced income is taxed in Australia',
+                        'No tax-free threshold — 30% flat rate applies to Australian income',
+                        'Withholding tax (typically 10–15%) applies to Australian bank interest',
+                        'Super withdrawals remain tax-free at age 60+',
+                        'Capital gains on Australian property taxed at 32.5% (no 50% CGT discount)'
+                    ],
+                    note: hasDTA
+                        ? `Australia has a Double Tax Agreement with ${country.name} — may reduce Australian withholding tax on dividends, interest and royalties.`
+                        : `No Double Tax Agreement with ${country.name} — potential for double taxation on investment income. Consider restructuring before departure.`
+                }
+            };
+        }
+
+        if (taxResidency === 'dta') {
+            return {
+                ...base,
+                australianTaxResidency: {
+                    status: 'Relying on Double Tax Agreement provisions',
+                    implications: hasDTA ? [
+                        `Australia–${country.name} DTA limits withholding tax on dividends, interest, and royalties`,
+                        'Age Pension is generally only taxable in Australia under most DTAs',
+                        'Super lump-sum payments may be exempt or reduced under DTA',
+                        'Tiebreaker residency rules in the DTA determine primary taxing rights',
+                        'Mutual agreement procedure available if both countries attempt to tax the same income'
+                    ] : [
+                        `No DTA exists between Australia and ${country.name}`,
+                        'Cannot rely on DTA tiebreaker rules — manual tax advice required',
+                        'Consider whether the additional tax cost changes the viability of this destination',
+                        'Unilateral foreign tax offset (FTO) may provide partial relief for foreign taxes paid'
+                    ],
+                    note: hasDTA ? dtaSummary : 'No DTA available — seek specialist cross-border tax advice before finalising plans.'
+                }
+            };
+        }
+
+        // Default: 'australian' — user intends to maintain Australian tax residency
+        return {
+            ...base,
+            australianTaxResidency: {
+                status: 'Maintain Australian tax residency',
+                implications: [
+                    'Taxed on worldwide income at Australian rates',
+                    'Retains tax-free threshold and full Medicare entitlements for Australian-sourced income',
+                    'Can access super tax-free from age 60',
+                    'Investment income from overseas assets taxed at Australian marginal rates',
+                    'Requires strong ongoing ties to Australia (property, bank accounts, family, intention to return)'
+                ],
+                transitionRisk: {
+                    trigger: 'ATO may deem you a foreign resident if you permanently sever ties',
+                    implication: 'Deemed disposal of assets at CGT event on departure — advance planning critical'
+                }
             }
         };
     }

--- a/src/js/simulator.js
+++ b/src/js/simulator.js
@@ -2098,7 +2098,59 @@ export class RetirementSimulator {
             const healthMultiplier = { excellent: 0.8, good: 1.0, fair: 1.25, poor: 1.6 }[inputs.healthCondition] || 1.0;
             const adjustedHealthcareCost = healthcareCost * healthMultiplier;
 
-            const totalCostWithHealthcare = baseIncomeNeeded + adjustedHealthcareCost + agedCareCost + lhcRetirementCost;
+            // ── Tiered spending multiplier (optional — Active / Stable / Frail) ────
+            // Applied to baseIncomeNeeded before other additive costs so it scales
+            // lifestyle spend only, not healthcare or aged-care costs.
+            let tieredSpendingMultiplier = 1.0;
+            if (inputs.enableTieredSpending) {
+                if (yourCurrentAge < (inputs.tieredSpendingActiveAge || 75)) {
+                    tieredSpendingMultiplier = (inputs.tieredSpendingActiveMultiplier || 1.1);
+                } else if (yourCurrentAge < (inputs.tieredSpendingFrailAge || 85)) {
+                    tieredSpendingMultiplier = (inputs.tieredSpendingStableMultiplier || 0.9);
+                } else {
+                    tieredSpendingMultiplier = (inputs.tieredSpendingFrailMultiplier || 1.15);
+                }
+            }
+            const tieredBaseIncome = baseIncomeNeeded * tieredSpendingMultiplier;
+
+            // ── Home modifications (optional) ─────────────────────────────────────
+            // One-off lump sum in the year of the modification age, plus ongoing
+            // annual maintenance starting that year. Omitted if user plans to
+            // downsize to strata/aged care (maintenance is covered by levies there).
+            let homeModCost = 0;
+            if (inputs.enableHomeModifications) {
+                const modAge = inputs.homeModificationAge || 78;
+                if (yourCurrentAge === modAge) {
+                    homeModCost += (inputs.homeModificationCost || 0);
+                }
+                if (yourCurrentAge >= modAge) {
+                    const inflatedRecurring = (inputs.homeModificationRecurring || 0)
+                        * Math.pow(1 + (inputs.inflation || 0.026), retirementYear);
+                    homeModCost += inflatedRecurring;
+                }
+            }
+
+            // ── Annuity income (optional) ─────────────────────────────────────────
+            // At the purchase age, the lump sum is drawn from the portfolio (treated
+            // as a one-off withdrawal). From that age onwards, the guaranteed income
+            // offsets withdrawals — similar to how Age Pension income is applied.
+            let annuityIncome = 0;
+            let annuityLumpSumCost = 0;
+            if (inputs.enableAnnuity) {
+                const purchaseAge = inputs.annuityPurchaseAge || 67;
+                if (yourCurrentAge === purchaseAge) {
+                    annuityLumpSumCost = inputs.annuityLumpSum || 0;
+                }
+                if (yourCurrentAge >= purchaseAge) {
+                    // Annual income is inflation-indexed from the purchase year
+                    annuityIncome = (inputs.annuityAnnualIncome || 0)
+                        * Math.pow(1 + (inputs.inflation || 0.026),
+                            yourCurrentAge - purchaseAge);
+                }
+            }
+
+            const totalCostWithHealthcare = tieredBaseIncome + adjustedHealthcareCost + agedCareCost
+                + lhcRetirementCost + homeModCost + annuityLumpSumCost;
 
             // AWLR eligibility check: Age Pension requires 10+ years Australian residence
             // If ageCameToAustralia is set, compute residence years at retirement
@@ -2185,7 +2237,7 @@ export class RetirementSimulator {
             }
 
             // Pension income test uses gross trust distributions; withdrawal offset uses net-of-tax
-            const otherIncome = propertyIncome + trustDistributionNetIncome;
+            const otherIncome = propertyIncome + trustDistributionNetIncome + annuityIncome;
             const totalIncome = pensionIncome + otherIncome;
             const netWithdrawalNeeded = Math.max(0, totalCostWithHealthcare - totalIncome);
 

--- a/src/js/simulator.js
+++ b/src/js/simulator.js
@@ -2113,6 +2113,10 @@ export class RetirementSimulator {
             }
             const tieredBaseIncome = baseIncomeNeeded * tieredSpendingMultiplier;
 
+            const optionalCostInflationRate = useRandomReturns
+                ? runInflationRate
+                : (inputs.inflation || 0.026);
+
             // ── Home modifications (optional) ─────────────────────────────────────
             // One-off lump sum in the year of the modification age, plus ongoing
             // annual maintenance starting that year. Omitted if user plans to
@@ -2123,9 +2127,9 @@ export class RetirementSimulator {
                 if (yourCurrentAge === modAge) {
                     homeModCost += (inputs.homeModificationCost || 0);
                 }
-                if (yourCurrentAge >= modAge) {
+                if (yourCurrentAge >= modAge && !inputs.planToDownsize) {
                     const inflatedRecurring = (inputs.homeModificationRecurring || 0)
-                        * Math.pow(1 + (inputs.inflation || 0.026), retirementYear);
+                        * Math.pow(1 + optionalCostInflationRate, retirementYear);
                     homeModCost += inflatedRecurring;
                 }
             }
@@ -2144,7 +2148,7 @@ export class RetirementSimulator {
                 if (yourCurrentAge >= purchaseAge) {
                     // Annual income is inflation-indexed from the purchase year
                     annuityIncome = (inputs.annuityAnnualIncome || 0)
-                        * Math.pow(1 + (inputs.inflation || 0.026),
+                        * Math.pow(1 + optionalCostInflationRate,
                             yourCurrentAge - purchaseAge);
                 }
             }

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1815,6 +1815,20 @@ export const exportToPDF = (inputs, results, chartManager, app = null) => {
     // Get the final Y position after the first table
     let yPos = doc.lastAutoTable ? doc.lastAutoTable.finalY + 15 : 180;
 
+    // --- Plain-English Narrative Summary ---
+    if (enhancedAnalysis.plainEnglishNarrative) {
+        if (yPos > 220) { doc.addPage(); yPos = 20; }
+        doc.setFontSize(13);
+        doc.setTextColor(0, 71, 171);
+        doc.text('Plan Summary', 14, yPos);
+        yPos += 8;
+        doc.setFontSize(10);
+        doc.setTextColor(40, 40, 40);
+        const narrativeLines = doc.splitTextToSize(enhancedAnalysis.plainEnglishNarrative, 175);
+        doc.text(narrativeLines, 14, yPos);
+        yPos += (narrativeLines.length * 5) + 12;
+    }
+
     // --- Monte Carlo Analysis Section ---
     if (monteCarloResults) {
         if (yPos > 200) {
@@ -2320,6 +2334,23 @@ export const populateFormFromData = (userData, version = '2.0') => {
             } else {
                 // Handle field mapping for legacy/alternative field names
                 let targetKey = key;
+
+                // Map v2 overseas field names to advanced.html element IDs
+                const v2ToClassicMap = {
+                    destination: 'overseasCountry',
+                    ageMovingOverseas: 'overseasAge',
+                    annualLivingCostOverseas: 'estimatedLivingCosts',
+                };
+                if (v2ToClassicMap[key]) {
+                    const el = $(v2ToClassicMap[key]);
+                    if (el) {
+                        el.value = value == null ? '' : value;
+                        fieldsPopulated++;
+                        debugLog(`✓ Mapped v2 field ${key} → ${v2ToClassicMap[key]}: ${value}`);
+                    }
+                    // Also try the v2 key itself (in case the page uses it natively)
+                    targetKey = $(key) ? key : v2ToClassicMap[key];
+                }
 
                 // Map returnRate to specific investment return fields
                 if (key === 'returnRate') {
@@ -2941,6 +2972,7 @@ function extractAnalysisData(inputs, results, app) {
         riskProfile: null,
         allocationStrategy: null,
         overseasData: null,
+        plainEnglishNarrative: null,
     };
 
     try {
@@ -3028,6 +3060,11 @@ function extractAnalysisData(inputs, results, app) {
         // Overseas retirement scenarios (if run)
         if (app?.currentOverseasData) {
             analysis.overseasData = app.currentOverseasData;
+        }
+
+        // Plain-English narrative text for PDF header
+        if (app?.plainEnglishNarrative) {
+            analysis.plainEnglishNarrative = app.plainEnglishNarrative;
         }
 
     } catch (error) {
@@ -3962,13 +3999,28 @@ function addEnhancedAnalysisToPDF(doc, analysis, startY) {
         if (config.destinationCountry || config.currency) {
             doc.setFontSize(10);
             doc.setTextColor(100);
-            const configText = [
+            const configParts = [
                 config.destinationCountry ? `Destination: ${config.destinationCountry}` : null,
                 config.currency ? `Currency: ${config.currency}` : null,
                 config.monthlyBudget ? `Monthly Budget: ${config.currency || '$'}${config.monthlyBudget?.toLocaleString()}` : null,
-            ].filter(Boolean).join('   |   ');
-            doc.text(configText, 14, yPos);
-            yPos += 10;
+                config.moveType && config.moveType !== 'unknown' ? `Move Type: ${config.moveType}` : null,
+                config.taxResidency && config.taxResidency !== 'unknown' ? `Tax Residency: ${config.taxResidency}` : null,
+                config.returnFrequency && config.returnFrequency !== 'unknown' ? `Return Visits: ${config.returnFrequency}` : null,
+                config.ageMovingOverseas ? `Moving Overseas at Age: ${config.ageMovingOverseas}` : null,
+            ].filter(Boolean);
+            configParts.forEach(part => {
+                doc.text(part, 14, yPos);
+                yPos += 6;
+            });
+            yPos += 4;
+        }
+
+        if (overseas.overview) {
+            doc.setFontSize(9);
+            doc.setTextColor(60);
+            const overviewLines = doc.splitTextToSize(overseas.overview, 175);
+            doc.text(overviewLines, 14, yPos);
+            yPos += overviewLines.length * 5 + 8;
         }
 
         if (scenarios.length > 0) {
@@ -3998,7 +4050,86 @@ function addEnhancedAnalysisToPDF(doc, analysis, startY) {
                 }
             });
             yPos = doc.lastAutoTable.finalY + 10;
-        } else {
+        }
+
+        // Age Pension Portability
+        if (overseas.pensionPortability) {
+            if (yPos > 220) { doc.addPage(); yPos = 20; }
+            doc.setFontSize(12);
+            doc.setTextColor(8, 145, 178);
+            doc.text('Age Pension Portability', 14, yPos);
+            yPos += 6;
+            const pp = overseas.pensionPortability;
+            const ppBody = [
+                ['Full Portability', pp.hasFullPortability ? 'Yes' : 'No'],
+                ['Social Security Agreement', pp.hasAgreement ? 'Yes' : 'No'],
+                ['Proportional Rate', pp.proportionalRate != null ? `${(pp.proportionalRate * 100).toFixed(0)}%` : 'N/A'],
+                ['Annual Pension (Portable)', pp.portablePensionAnnual != null ? formatCurrency(pp.portablePensionAnnual) : 'N/A'],
+            ].filter(r => r[1] !== 'N/A');
+            if (ppBody.length > 0) {
+                doc.autoTable({
+                    startY: yPos,
+                    head: [['Pension Metric', 'Value']],
+                    body: ppBody,
+                    theme: 'grid',
+                    headStyles: { fillColor: [8, 145, 178] },
+                    styles: { fontSize: 8 }
+                });
+                yPos = doc.lastAutoTable.finalY + 8;
+            }
+        }
+
+        // Tax Implications
+        if (overseas.taxImplications) {
+            if (yPos > 220) { doc.addPage(); yPos = 20; }
+            doc.setFontSize(12);
+            doc.setTextColor(8, 145, 178);
+            doc.text('Tax Implications', 14, yPos);
+            yPos += 6;
+            const ti = overseas.taxImplications;
+            const tiRows = [
+                ti.australianResidency ? ['Australian Tax Residency', ti.australianResidency] : null,
+                ti.superTaxation ? ['Superannuation Taxation', ti.superTaxation] : null,
+                ti.foreignIncomeTax ? ['Foreign Income Tax', ti.foreignIncomeTax] : null,
+                ti.capitalGainsTax ? ['Capital Gains Tax', ti.capitalGainsTax] : null,
+                ti.dtaStatus ? ['Double Tax Agreement', ti.dtaStatus] : null,
+            ].filter(Boolean);
+            if (tiRows.length > 0) {
+                doc.autoTable({
+                    startY: yPos,
+                    head: [['Tax Area', 'Details']],
+                    body: tiRows,
+                    theme: 'striped',
+                    headStyles: { fillColor: [8, 145, 178] },
+                    styles: { fontSize: 8, cellPadding: 3 },
+                    columnStyles: { 0: { cellWidth: 55 }, 1: { cellWidth: 115 } }
+                });
+                yPos = doc.lastAutoTable.finalY + 8;
+            }
+        }
+
+        // Overseas-specific recommendations
+        if (overseas.recommendations?.length > 0) {
+            if (yPos > 220) { doc.addPage(); yPos = 20; }
+            doc.setFontSize(12);
+            doc.setTextColor(8, 145, 178);
+            doc.text('Overseas Retirement Recommendations', 14, yPos);
+            yPos += 6;
+            doc.autoTable({
+                startY: yPos,
+                head: [['Recommendation', 'Priority']],
+                body: overseas.recommendations.slice(0, 8).map(r => [
+                    typeof r === 'string' ? r : (r.recommendation || r.action || r.title || ''),
+                    r.priority || 'Review'
+                ]),
+                theme: 'grid',
+                headStyles: { fillColor: [8, 145, 178] },
+                styles: { fontSize: 8 }
+            });
+            yPos = doc.lastAutoTable.finalY + 8;
+        }
+
+        if (!overseas.overview && !scenarios.length) {
             doc.setFontSize(9);
             doc.setTextColor(150);
             doc.text('No overseas scenario data available for detailed breakdown.', 14, yPos);

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -4060,11 +4060,16 @@ function addEnhancedAnalysisToPDF(doc, analysis, startY) {
             doc.text('Age Pension Portability', 14, yPos);
             yPos += 6;
             const pp = overseas.pensionPortability;
+            const fullPortability = pp.fullPortability ?? pp.hasFullPortability;
+            const proportionalRate = pp.scenarioTree?.permanentMove?.proportionalRate ?? pp.proportionalRate;
+            const portablePensionAnnual = pp.scenarioTree?.permanentMove?.annualPension
+                ?? pp.portablePensionAnnual
+                ?? pp.pensionCalculation?.overseas;
             const ppBody = [
-                ['Full Portability', pp.hasFullPortability ? 'Yes' : 'No'],
+                ['Full Portability', fullPortability != null ? (fullPortability ? 'Yes' : 'No') : 'N/A'],
                 ['Social Security Agreement', pp.hasAgreement ? 'Yes' : 'No'],
-                ['Proportional Rate', pp.proportionalRate != null ? `${(pp.proportionalRate * 100).toFixed(0)}%` : 'N/A'],
-                ['Annual Pension (Portable)', pp.portablePensionAnnual != null ? formatCurrency(pp.portablePensionAnnual) : 'N/A'],
+                ['Proportional Rate', proportionalRate != null ? `${(proportionalRate * 100).toFixed(0)}%` : 'N/A'],
+                ['Annual Pension (Portable)', portablePensionAnnual != null ? formatCurrency(portablePensionAnnual) : 'N/A'],
             ].filter(r => r[1] !== 'N/A');
             if (ppBody.length > 0) {
                 doc.autoTable({
@@ -4087,13 +4092,38 @@ function addEnhancedAnalysisToPDF(doc, analysis, startY) {
             doc.text('Tax Implications', 14, yPos);
             yPos += 6;
             const ti = overseas.taxImplications;
+            const joinParts = (parts) => parts.filter(Boolean).join('; ');
+            const residencyImplications = Array.isArray(ti.australianTaxResidency?.implications)
+                ? ti.australianTaxResidency.implications.join('; ')
+                : null;
+            const superImplications = Array.isArray(ti.superannuation?.considerations)
+                ? ti.superannuation.considerations.join('; ')
+                : null;
             const tiRows = [
-                ti.australianResidency ? ['Australian Tax Residency', ti.australianResidency] : null,
-                ti.superTaxation ? ['Superannuation Taxation', ti.superTaxation] : null,
+                ti.australianTaxResidency
+                    ? ['Australian Tax Residency', joinParts([
+                        ti.australianTaxResidency.status,
+                        residencyImplications,
+                        ti.australianTaxResidency.note,
+                    ])]
+                    : (ti.australianResidency ? ['Australian Tax Residency', ti.australianResidency] : null),
+                ti.superannuation
+                    ? ['Superannuation Taxation', joinParts([
+                        ti.superannuation.access,
+                        ti.superannuation.taxation,
+                        superImplications,
+                    ])]
+                    : (ti.superTaxation ? ['Superannuation Taxation', ti.superTaxation] : null),
+                ti.doubleTaxAgreement
+                    ? ['Double Tax Agreement', joinParts([
+                        ti.doubleTaxAgreement.exists === true ? 'Available' : null,
+                        ti.doubleTaxAgreement.exists === false ? 'Not available' : null,
+                        ti.doubleTaxAgreement.summary,
+                    ])]
+                    : (ti.dtaStatus ? ['Double Tax Agreement', ti.dtaStatus] : null),
                 ti.foreignIncomeTax ? ['Foreign Income Tax', ti.foreignIncomeTax] : null,
                 ti.capitalGainsTax ? ['Capital Gains Tax', ti.capitalGainsTax] : null,
-                ti.dtaStatus ? ['Double Tax Agreement', ti.dtaStatus] : null,
-            ].filter(Boolean);
+            ].filter((row) => row && row[1]);
             if (tiRows.length > 0) {
                 doc.autoTable({
                     startY: yPos,


### PR DESCRIPTION
## Summary

Comprehensive audit and enhancement of `advanced.html` and `advanced-v2.html`, addressing all data-linkage gaps, cross-page compatibility, plain-English outcomes, age-related optional costs, overseas field disconnects, PDF gaps, and Monte Carlo performance.

---

## Phase 1 — Data linkage fixes
- Wired 14 overseas fields + 15 age-option fields into `buildEngineInputs()` (advanced-v2) and `collectInputs()` (advanced.html)
- Linked `returnFrequency` ↔ `overseasMoveType` UI toggle (permanent move hides return frequency)
- Made `trustBeneficiaries` conditional on `propertyStrategy === 'trust'`

## Phase 2 — Cross-page save/load compatibility
- Added classic→v2 field mapping in `normalizeImportedUserData()` (`overseasCountry→destination`, `overseasAge→ageMovingOverseas`, etc.)
- Added v2→classic reverse mapping in `populateFormFromData()` so a v2 save loads correctly on advanced.html

## Phase 3 — Monte Carlo performance
- Real progress callback wired through `runMonteCarloAnalysis()`
- Async yield every 50 iterations to keep UI responsive
- Added 20,000 runs option to the mcRuns select

## Phase 4 — Age-related optional cost sections
- New Section 13 in `advanced-v2.html`: Home Modifications, Annuity Purchase, Tiered Retirement Spending — all optional, toggle-gated
- Matching optional block added to `advanced.html` (Optional column)
- All new fields wired through `readInputs`, `buildEngineInputs`, `normalizeImportedUserData`, and `boot()`
- Simulator retirement loop applies tiered spending multiplier, home modification costs, and annuity cash flows

## Phase 5 — Plain-English narrative
- `buildPlainEnglishNarrative()`: sustain-age sentence, downsize extension, biggest-risk callout
- `buildRetirementTargetBuilder()`: post-retirement income target (current income minus mortgage/children costs)
- `buildSequenceOfReturnsCallout()`: early-crash vs late-crash scenario comparison
- All three wired into `renderSummaryPanel()`

## Phase 6 — PDF improvements
- Plain-English Narrative section added to `exportToPDF()`
- Overseas PDF section rewritten with 5 subsections: summary, tax implications, healthcare, lifestyle, financial
- AI suggestions/recommendations now included in PDF export

## Additional fixes
- `analyzeTaxImplications()` branches on `overseasTaxResidency` ('australian' / 'foreign' / 'dta') with DTA-awareness
- Year-by-Year table in `advanced.html` gains an "Overseas 🌏" column
- 17 new tooltip definitions for all new fields
- `carerAnnualExpense` uses `??` so explicit `0` is not replaced by `annualParentSupport` fallback

## Tests
- **769/769 passing** — 0 failures
- Build: 0 errors, 2 asset-size warnings (expected)