### PR TITLE
feat: stochastic per-year rates, median MC output, ageism salary model, PDF fixes

### DIFF
--- a/src/js/advanced-design-engine.js
+++ b/src/js/advanced-design-engine.js
@@ -95,6 +95,32 @@ const applyMeansTest = (totalAssets, annualIncome, maxPension, assetThreshold, a
     return Math.min(fromAssets, fromIncome);
 };
 
+// ── Stochastic helpers (inlined — no external imports allowed in this module) ─
+
+/**
+ * Draw one value from N(mean, sigma) using the Box-Muller transform.
+ * Each call consumes two independent uniform samples from Math.random().
+ */
+const normalDraw = (mean, sigma) => {
+    const u1 = Math.max(1e-10, Math.random());
+    const u2 = Math.random();
+    const z  = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+    return mean + z * sigma;
+};
+
+/**
+ * Compute the median of an unsorted numeric array.
+ * Returns 0 for empty arrays.
+ */
+const arrayMedian = (arr) => {
+    if (!arr.length) return 0;
+    const sorted = [...arr].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    return sorted.length % 2 === 0
+        ? (sorted[mid - 1] + sorted[mid]) / 2
+        : sorted[mid];
+};
+
 // ── Pipeline C engine ─────────────────────────────────────────────────────────
 
 /**
@@ -125,8 +151,36 @@ export class AdvancedDesignEngine {
      *
      * All rate inputs are plain percentages (e.g. 7.5 for 7.5%).
      * Boolean inputs: realTerms, inflationAdjusted, isCouple, homeowner.
+     *
+     * Runs 500 Monte Carlo paths with per-year stochastic rates and returns
+     * the MEDIAN outcome so the result reflects realistic sequence-of-return
+     * risk rather than a single fixed-rate projection.
+     *
+     * The returned object includes the full median-run detail (yearByYear,
+     * retirementBalance, etc.) plus MC summary fields: successRate, p10Income,
+     * p90Income, and mcRuns.
      */
     calculate(inputs) {
+        const p = this._normalise(inputs);
+        const numRuns = Number(inputs.numMonteCarloRuns) || 500;
+        const mc = this._runMonteCarlo(p, numRuns);
+        return {
+            ...mc.medianResult,
+            successRate: mc.successRate,
+            p10Income:   mc.p10Income,
+            p90Income:   mc.p90Income,
+            mcRuns:      mc.runs,
+        };
+    }
+
+    /**
+     * calculateDeterministic(inputs) → single fixed-rate projection
+     *
+     * Returns a single deterministic run using the user's exact input rates
+     * for every year.  Use this for explainability / "show your workings"
+     * while the main calculate() result is MC-median.
+     */
+    calculateDeterministic(inputs) {
         const p = this._normalise(inputs);
         return this._runSimulation(p);
     }
@@ -150,9 +204,16 @@ export class AdvancedDesignEngine {
         return result;
     }
 
-    /** calculateSensitivity(inputs) → array of top-3 sensitivity drivers */
+    /**
+     * calculateSensitivity(inputs) → array of top-3 sensitivity drivers
+     *
+     * Uses deterministic projections for comparing parameter deltas so that
+     * small differences are not obscured by MC variance.  The main calculate()
+     * result (MC median) is used as the baseline income display value only.
+     */
     calculateSensitivity(inputs) {
-        const base = this.calculate(inputs);
+        // Deterministic baseline for clean delta comparisons
+        const base = this.calculateDeterministic(inputs);
         const baseIncome = base.annualRetirementIncome;
 
         const drivers = [
@@ -167,7 +228,7 @@ export class AdvancedDesignEngine {
         return drivers
             .map(d => {
                 let modIncome;
-                try { modIncome = this.calculate(Object.assign({}, inputs, { [d.key]: inputs[d.key] + d.delta })).annualRetirementIncome; }
+                try { modIncome = this.calculateDeterministic(Object.assign({}, inputs, { [d.key]: inputs[d.key] + d.delta })).annualRetirementIncome; }
                 catch { modIncome = baseIncome; }
                 const impact = modIncome - baseIncome;
                 return { driver: d.key, label: d.label, delta: d.delta, unit: d.unit, impact, direction: impact >= 0 ? 'positive' : 'negative', description: this._sensitivityDescription(d, impact, inputs) };
@@ -218,10 +279,26 @@ export class AdvancedDesignEngine {
         return n > 1 ? n / 100 : n;
     }
 
-    /** Core simulation loop. stress = null | { stressType, stressYear } */
-    _runSimulation(p, stress = null) {
+    /**
+     * Core simulation loop.
+     *
+     * @param {Object}  p          – normalised parameter object
+     * @param {Object}  [stress]   – null | { stressType, stressYear }
+     * @param {boolean} [stochastic=false] – when true, draws a fresh rate from a
+     *   normal distribution each year instead of using the fixed median rate.
+     *   Enables realistic sequence-of-return risk beyond named stress scenarios.
+     * @returns simulation result object
+     */
+    _runSimulation(p, stress = null, stochastic = false) {
         const yearsToRetirement = Math.max(0, p.retirementAge - p.currentAge);
         const yearsInRetirement = Math.max(0, p.planningHorizon - p.retirementAge);
+
+        // Volatility parameters for per-year normal draws.
+        // Super/savings: σ = max(3%, rate×60%) — balanced-fund volatility
+        // Inflation: σ = max(0.5%, rate×40%) — CPI year-to-year variation
+        const superSigma    = Math.max(0.03, Math.abs(p.superReturn)    * 0.6);
+        const savingsSigma  = Math.max(0.005, Math.abs(p.savingsReturn) * 0.3);
+        const inflationSigma = Math.max(0.005, Math.abs(p.inflation)    * 0.4);
 
         // ── Accumulation ─────────────────────────────────────────────────
         let superBal   = p.currentSuper;
@@ -230,9 +307,20 @@ export class AdvancedDesignEngine {
         let cpiFactor = 1;
 
         for (let yr = 0; yr < yearsToRetirement; yr++) {
-            superBal    = (superBal    + p.annualContribution)    * (1 + p.superReturn);
-            savingsBal  = (savingsBal  + p.annualSavingsContrib)  * (1 + p.savingsReturn);
-            cpiFactor  *= (1 + p.inflation);
+            // Per-year rate draws (stochastic) or fixed median (deterministic)
+            const yrSuperReturn   = stochastic
+                ? Math.max(-0.30, normalDraw(p.superReturn,   superSigma))
+                : p.superReturn;
+            const yrSavingsReturn = stochastic
+                ? Math.max(0,     normalDraw(p.savingsReturn, savingsSigma))
+                : p.savingsReturn;
+            const yrInflation     = stochastic
+                ? Math.max(0.001, normalDraw(p.inflation,     inflationSigma))
+                : p.inflation;
+
+            superBal    = (superBal    + p.annualContribution)    * (1 + yrSuperReturn);
+            savingsBal  = (savingsBal  + p.annualSavingsContrib)  * (1 + yrSavingsReturn);
+            cpiFactor  *= (1 + yrInflation);
             const display = p.realTerms ? 1 / cpiFactor : 1;
             yearByYear.push({
                 age:            p.currentAge + yr,
@@ -263,13 +351,27 @@ export class AdvancedDesignEngine {
         for (let yr = 0; yr < yearsInRetirement; yr++) {
             const age     = p.retirementAge + yr;
             const retirYr = yr + 1;
-            cpiFactor    *= (1 + p.inflation);
 
-            if (p.inflationAdjusted && yr > 0) withdrawal *= (1 + p.inflation);
+            // Per-year stochastic draws for decumulation phase
+            const yrSuperReturn   = stochastic
+                ? Math.max(-0.30, normalDraw(p.superReturn,   superSigma))
+                : p.superReturn;
+            const yrSavingsReturn = stochastic
+                ? Math.max(0,     normalDraw(p.savingsReturn, savingsSigma))
+                : p.savingsReturn;
+            const yrInflation     = stochastic
+                ? Math.max(0.001, normalDraw(p.inflation,     inflationSigma))
+                : p.inflation;
 
-            let superRet   = p.superReturn;
-            let savingsRet = p.savingsReturn;
+            cpiFactor *= (1 + yrInflation);
 
+            // Inflation-adjust withdrawal using per-year drawn inflation
+            if (p.inflationAdjusted && yr > 0) withdrawal *= (1 + yrInflation);
+
+            let superRet   = yrSuperReturn;
+            let savingsRet = yrSavingsReturn;
+
+            // Stress scenarios override stochastic rates
             if (stress) {
                 if (stress.stressType === 'sequence-of-returns' && retirYr <= 3) {
                     superRet = savingsRet = -0.10;
@@ -328,6 +430,53 @@ export class AdvancedDesignEngine {
             retirementAge:       p.retirementAge,
             agePensionEstimate:  Math.round(agePensionEstimate),
             yearByYear,
+        };
+    }
+
+    /**
+     * Run N Monte Carlo simulations with per-year stochastic rates and return
+     * the MEDIAN outcome across all runs.  Each run draws a fresh independent
+     * rate for every year so no two years share the same growth assumption.
+     *
+     * The median (p50) is returned as the primary result because it is more
+     * robust to outlier runs than the arithmetic mean.
+     *
+     * @param {Object} p          – normalised parameter object
+     * @param {number} [numRuns=500] – number of MC paths to simulate
+     * @returns {{ medianResult, successRate, p10Result, p90Result }}
+     */
+    _runMonteCarlo(p, numRuns = 500) {
+        const results = [];
+        for (let i = 0; i < numRuns; i++) {
+            results.push(this._runSimulation(p, null, true));
+        }
+
+        // Sort by final retirement balance to derive percentile outcomes
+        const sorted = [...results].sort((a, b) => a.retirementBalance - b.retirementBalance);
+        const mid    = Math.floor(sorted.length / 2);
+        const medianResult = sorted.length % 2 === 0
+            ? sorted[mid]          // lower-mid for even (conservative median)
+            : sorted[mid];
+
+        // Success rate: fraction of runs that never depleted the portfolio
+        const successCount = results.filter(r => r.depletionYear === null).length;
+        const successRate  = successCount / numRuns;
+
+        // Median annual income across all runs (primary output)
+        const incomes = results.map(r => r.annualRetirementIncome);
+        const medianIncome = arrayMedian(incomes);
+
+        // p10 / p90 income band for display
+        const sortedIncomes = [...incomes].sort((a, b) => a - b);
+        const p10Income = sortedIncomes[Math.floor(sortedIncomes.length * 0.10)];
+        const p90Income = sortedIncomes[Math.floor(sortedIncomes.length * 0.90)];
+
+        return {
+            medianResult:   { ...medianResult, annualRetirementIncome: Math.round(medianIncome) },
+            successRate,
+            p10Income:      Math.round(p10Income),
+            p90Income:      Math.round(p90Income),
+            runs:           numRuns,
         };
     }
 

--- a/src/js/advanced-design-engine.js
+++ b/src/js/advanced-design-engine.js
@@ -451,32 +451,28 @@ export class AdvancedDesignEngine {
             results.push(this._runSimulation(p, null, true));
         }
 
-        // Sort by final retirement balance to derive percentile outcomes
-        const sorted = [...results].sort((a, b) => a.retirementBalance - b.retirementBalance);
-        const mid    = Math.floor(sorted.length / 2);
-        const medianResult = sorted.length % 2 === 0
-            ? sorted[mid]          // lower-mid for even (conservative median)
-            : sorted[mid];
+        // Sort by annualRetirementIncome to find the run whose income is the
+        // median — this ensures the returned medianResult is a self-consistent
+        // single simulation run (all fields from the same run).  Using the
+        // median-income run is preferable to mixing fields from different runs.
+        const sortedByIncome = [...results].sort((a, b) => a.annualRetirementIncome - b.annualRetirementIncome);
+        const mid            = Math.floor(sortedByIncome.length / 2);
+        const medianResult   = sortedByIncome[mid];
 
         // Success rate: fraction of runs that never depleted the portfolio
         const successCount = results.filter(r => r.depletionYear === null).length;
         const successRate  = successCount / numRuns;
 
-        // Median annual income across all runs (primary output)
-        const incomes = results.map(r => r.annualRetirementIncome);
-        const medianIncome = arrayMedian(incomes);
-
         // p10 / p90 income band for display
-        const sortedIncomes = [...incomes].sort((a, b) => a - b);
-        const p10Income = sortedIncomes[Math.floor(sortedIncomes.length * 0.10)];
-        const p90Income = sortedIncomes[Math.floor(sortedIncomes.length * 0.90)];
+        const p10Income = sortedByIncome[Math.floor(sortedByIncome.length * 0.10)].annualRetirementIncome;
+        const p90Income = sortedByIncome[Math.floor(sortedByIncome.length * 0.90)].annualRetirementIncome;
 
         return {
-            medianResult:   { ...medianResult, annualRetirementIncome: Math.round(medianIncome) },
+            medianResult,
             successRate,
-            p10Income:      Math.round(p10Income),
-            p90Income:      Math.round(p90Income),
-            runs:           numRuns,
+            p10Income:  Math.round(p10Income),
+            p90Income:  Math.round(p90Income),
+            runs:       numRuns,
         };
     }
 

--- a/src/js/advanced-design-ui.js
+++ b/src/js/advanced-design-ui.js
@@ -488,6 +488,19 @@ class AdvancedDesignUI {
             }
         }
 
+        // Monte Carlo statistics — show success rate and income range when present
+        const mcEl = document.getElementById('res-mc-stats');
+        if (mcEl && results.mcRuns) {
+            const successPct = Math.round((results.successRate || 0) * 100);
+            const p10 = fmt(results.p10Income || 0);
+            const p90 = fmt(results.p90Income || 0);
+            let colour = successPct >= 80 ? 'text-green-700' : successPct >= 60 ? 'text-amber-600' : 'text-red-600';
+            mcEl.innerHTML =
+                `<span class="${colour} font-semibold">${successPct}% probability of success</span>` +
+                ` &nbsp;·&nbsp; income range (p10–p90): ${p10} – ${p90}/yr` +
+                ` &nbsp;·&nbsp; <span class="text-gray-500 text-xs">${results.mcRuns} simulations (median shown)</span>`;
+        }
+
         // Real/Nominal label
         const termLabel = document.getElementById('res-termLabel');
         if (termLabel) {

--- a/src/js/advanced-v2.js
+++ b/src/js/advanced-v2.js
@@ -1440,6 +1440,7 @@ function buildExportAppBridge() {
     currentMonteCarloResults: APP_STATE.monteCarloResults,
     currentRecommendations: APP_STATE.recommendations,
     currentComprehensiveRecommendations: APP_STATE.recommendations,
+    currentSuggestions: APP_STATE.recommendations,
     currentStressTestResults: APP_STATE.stressTestResults,
     currentRiskProfile: APP_STATE.riskProfile,
     currentAllocationStrategy: APP_STATE.allocationStrategy,
@@ -3308,17 +3309,20 @@ async function applyRecommendationScenario(rec) {
 /** Export selected action plan items and readiness summary to PDF. */
 async function exportSuggestionsAsPdf(selectedRecs, band) {
   showNotification('Preparing PDF…', 'info');
-  const baseState = syncAppState();
-  await exportToPDF(baseState.input, APP_STATE.simulation, {
-    monteCarloResults: APP_STATE.monteCarloResults,
-    recommendations: selectedRecs.length ? selectedRecs : (APP_STATE.recommendations || []),
-    outcomeBand: band,
-    stressTestResults: APP_STATE.stressTestResults,
-    riskProfile: APP_STATE.riskProfile,
-    allocationStrategy: APP_STATE.allocationStrategy,
-    overseasAnalysis: APP_STATE.overseasAnalysis,
-    overseasExportData: APP_STATE.overseasExportData,
-  });
+  syncAppState();
+  const recs = selectedRecs.length ? selectedRecs : (APP_STATE.recommendations || []);
+  await exportToPDF(
+    APP_STATE.engineInputs,
+    buildExportResults(),
+    APP_STATE.chartManager,
+    {
+      ...buildExportAppBridge(),
+      currentSuggestions: recs,
+      currentRecommendations: recs,
+      currentComprehensiveRecommendations: recs,
+      currentOutcomeBand: band,
+    }
+  );
 }
 
 function renderAnalysisPanels() {

--- a/src/js/simulation_engine/expense_engine.js
+++ b/src/js/simulation_engine/expense_engine.js
@@ -43,7 +43,7 @@ export const getSpendingPhaseMultiplier = (age, retirementAge) => {
  * @param {Object} inputs              – user inputs
  * @returns {number} projected annual living expenses
  */
-export const projectLivingExpenses = (currentExpenses, age, inputs) => {
+export const projectLivingExpenses = (currentExpenses, age, inputs, yearInflation = null) => {
     const {
         retirementAge = 65,
         inflation = 0.026,
@@ -52,8 +52,12 @@ export const projectLivingExpenses = (currentExpenses, age, inputs) => {
         leanYearsReduction = 0.38,
     } = inputs;
 
+    // Use the per-year drawn rate when provided (stochastic MC mode),
+    // otherwise fall back to the user's median inflation input.
+    const effectiveInflation = yearInflation !== null ? yearInflation : inflation;
+
     // Inflate expenses each year
-    let expenses = currentExpenses * (1 + inflation);
+    let expenses = currentExpenses * (1 + effectiveInflation);
 
     if (age >= retirementAge) {
         // Apply spending phase multiplier (U-shaped retirement spending curve)
@@ -78,10 +82,14 @@ export const projectLivingExpenses = (currentExpenses, age, inputs) => {
  * @param {Object} inputs                  – user inputs
  * @returns {number} projected annual healthcare costs
  */
-export const projectHealthcareCosts = (currentHealthcareCosts, age, inputs) => {
+export const projectHealthcareCosts = (currentHealthcareCosts, age, inputs, yearHealthcareInflation = null) => {
     const { healthcareInflation = 0.0382 } = inputs;
 
-    let costs = currentHealthcareCosts * (1 + healthcareInflation);
+    // Use the per-year drawn rate when provided (stochastic MC mode),
+    // otherwise fall back to the user's median healthcare inflation input.
+    const effectiveHcInflation = yearHealthcareInflation !== null ? yearHealthcareInflation : healthcareInflation;
+
+    let costs = currentHealthcareCosts * (1 + effectiveHcInflation);
 
     // Additional loading for older ages
     if (age >= 75 && age < 85) {

--- a/src/js/simulation_engine/income_engine.js
+++ b/src/js/simulation_engine/income_engine.js
@@ -14,7 +14,7 @@
  * @param {Object} inputs             – user inputs (decimal rates)
  * @returns {number} updated gross salary
  */
-export const projectSalary = (currentSalary, age, inputs) => {
+export const projectSalary = (currentSalary, age, inputs, yearSalaryGrowthRate = null) => {
     const {
         retirementAge = 65,
         salaryGrowthRate = 0.015,
@@ -27,7 +27,10 @@ export const projectSalary = (currentSalary, age, inputs) => {
     // Fully retired
     if (age >= retirementAge) return 0;
 
-    let salary = currentSalary * (1 + salaryGrowthRate);
+    // Use per-year draw when provided (stochastic MC mode); otherwise fixed median.
+    // Salary growth σ = max(0.5%, rate×40%) — modest year-to-year wage variation.
+    const effectiveGrowthRate = yearSalaryGrowthRate !== null ? yearSalaryGrowthRate : salaryGrowthRate;
+    let salary = currentSalary * (1 + effectiveGrowthRate);
 
     // Optional income-drop event (e.g. reduced hours, career change)
     if (incomeDropAge !== null && age >= incomeDropAge && age < retirementAge) {
@@ -55,14 +58,15 @@ export const projectSalary = (currentSalary, age, inputs) => {
  * @param {Object} inputs  – uses partnerRetirementAge, salaryGrowthRate
  * @returns {number}
  */
-export const projectPartnerSalary = (currentSalary, age, inputs) => {
+export const projectPartnerSalary = (currentSalary, age, inputs, yearSalaryGrowthRate = null) => {
     const {
         partnerRetirementAge = 65,
         salaryGrowthRate = 0.015,
     } = inputs;
 
     if (age >= partnerRetirementAge) return 0;
-    return currentSalary * (1 + salaryGrowthRate);
+    const effectiveGrowthRate = yearSalaryGrowthRate !== null ? yearSalaryGrowthRate : salaryGrowthRate;
+    return currentSalary * (1 + effectiveGrowthRate);
 };
 
 /**

--- a/src/js/simulation_engine/income_engine.js
+++ b/src/js/simulation_engine/income_engine.js
@@ -31,17 +31,22 @@ export const projectSalary = (currentSalary, age, inputs, yearSalaryGrowthRate =
     // Salary growth σ = max(0.5%, rate×40%) — modest year-to-year wage variation.
     let effectiveGrowthRate = yearSalaryGrowthRate !== null ? yearSalaryGrowthRate : salaryGrowthRate;
 
-    // Age-based ageism: growth slows or stalls in later career years due to
-    // discrimination, reduced advancement, and health factors.
-    const ageismStartAge = inputs.ageismStartAge ?? 50;
-    if (age >= ageismStartAge && age < retirementAge) {
-        const yearsAfterAgeism = age - ageismStartAge;
-        if (yearsAfterAgeism < 3) {
-            // Static phase for first 3 years: no real growth
-            effectiveGrowthRate = Math.min(effectiveGrowthRate, 0.0);
-        } else {
-            // Recovery phase: capped at 0.5% real growth
-            effectiveGrowthRate = Math.min(effectiveGrowthRate, 0.005);
+    // Age-based ageism (opt-in via inputs.enableAgeism).
+    // Models the real-world pattern where salary growth slows in later career
+    // due to age discrimination, reduced advancement, and health factors:
+    //   - First 3 years after ageismStartAge: no nominal growth (real salary declines)
+    //   - Thereafter: nominal growth capped at 0.5% (below CPI → continued real decline)
+    // NOTE: effectiveGrowthRate here is a NOMINAL rate applied directly to currentSalary.
+    // Capping at 0 = zero nominal growth; actual purchasing power erodes with inflation.
+    if (inputs.enableAgeism) {
+        const ageismStartAge = inputs.ageismStartAge ?? 50;
+        if (age >= ageismStartAge && age < retirementAge) {
+            const yearsAfterAgeism = age - ageismStartAge;
+            if (yearsAfterAgeism < 3) {
+                effectiveGrowthRate = Math.min(effectiveGrowthRate, 0.0);
+            } else {
+                effectiveGrowthRate = Math.min(effectiveGrowthRate, 0.005);
+            }
         }
     }
 

--- a/src/js/simulation_engine/income_engine.js
+++ b/src/js/simulation_engine/income_engine.js
@@ -29,7 +29,22 @@ export const projectSalary = (currentSalary, age, inputs, yearSalaryGrowthRate =
 
     // Use per-year draw when provided (stochastic MC mode); otherwise fixed median.
     // Salary growth σ = max(0.5%, rate×40%) — modest year-to-year wage variation.
-    const effectiveGrowthRate = yearSalaryGrowthRate !== null ? yearSalaryGrowthRate : salaryGrowthRate;
+    let effectiveGrowthRate = yearSalaryGrowthRate !== null ? yearSalaryGrowthRate : salaryGrowthRate;
+
+    // Age-based ageism: growth slows or stalls in later career years due to
+    // discrimination, reduced advancement, and health factors.
+    const ageismStartAge = inputs.ageismStartAge ?? 50;
+    if (age >= ageismStartAge && age < retirementAge) {
+        const yearsAfterAgeism = age - ageismStartAge;
+        if (yearsAfterAgeism < 3) {
+            // Static phase for first 3 years: no real growth
+            effectiveGrowthRate = Math.min(effectiveGrowthRate, 0.0);
+        } else {
+            // Recovery phase: capped at 0.5% real growth
+            effectiveGrowthRate = Math.min(effectiveGrowthRate, 0.005);
+        }
+    }
+
     let salary = currentSalary * (1 + effectiveGrowthRate);
 
     // Optional income-drop event (e.g. reduced hours, career change)

--- a/src/js/simulation_engine/investment_engine.js
+++ b/src/js/simulation_engine/investment_engine.js
@@ -45,9 +45,24 @@ export const growInvestmentAssets = (currentAssets, netContribution, inputs, sho
  * @param {Object} inputs           – savingsReturn, inflation
  * @returns {number} end-of-year savings
  */
-export const growSavings = (currentSavings, netContribution, inputs) => {
-    const { savingsReturn = 0.014 } = inputs;
-    return Math.max(0, (currentSavings + netContribution) * (1 + savingsReturn));
+export const growSavings = (currentSavings, netContribution, inputs, yearSavingsReturn = null) => {
+    const { savingsReturn = 0.014, useStochasticReturns = false } = inputs;
+
+    let effectiveReturn;
+    if (yearSavingsReturn !== null) {
+        effectiveReturn = yearSavingsReturn;
+    } else if (useStochasticReturns) {
+        // Per-year normal draw: σ = max(0.5%, rate×30%) for savings/cash instruments
+        const sigma = Math.max(0.005, Math.abs(savingsReturn) * 0.3);
+        const u1 = Math.max(1e-10, Math.random());
+        const u2 = Math.random();
+        const z  = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+        effectiveReturn = Math.max(0, savingsReturn + z * sigma); // savings can't go negative (bank guarantee)
+    } else {
+        effectiveReturn = savingsReturn;
+    }
+
+    return Math.max(0, (currentSavings + netContribution) * (1 + effectiveReturn));
 };
 
 export default { growInvestmentAssets, growSavings };

--- a/src/js/simulation_engine/life_simulation_engine.js
+++ b/src/js/simulation_engine/life_simulation_engine.js
@@ -160,8 +160,41 @@ export const runLifeSimulation = (userInputs) => {
             ? inputs.partnerCurrentAge + yearsElapsed
             : 0;
 
-        // Stochastic shocks
-        currentInflation = applyInflationShock(inflation, inputs);
+        // ── Per-year stochastic rate draws ────────────────────────────────────
+        // In stochastic (MC) mode each year draws its own independent rate from a
+        // normal distribution centred on the user's median input, so successive years
+        // see different inflation/return values rather than a single fixed compound.
+        // In deterministic mode these collapse to the user's exact input values.
+        let yearInflationRate = inflation;
+        let yearHcInflationRate = inputs.healthcareInflation || 0.0382;
+        let yearPropertyGrowthRate = inputs.propertyGrowthRate || 0.058;
+
+        if (useStochasticReturns) {
+            // Inflation: σ = max(0.5%, inflation×40%) — moderate year-to-year CPI variation
+            const inflSigma = Math.max(0.005, inflation * 0.4);
+            const [ui1, ui2] = [Math.max(1e-10, Math.random()), Math.random()];
+            const zi = Math.sqrt(-2 * Math.log(ui1)) * Math.cos(2 * Math.PI * ui2);
+            yearInflationRate = Math.max(0.001, inflation + zi * inflSigma);
+
+            // Healthcare inflation: σ = max(1%, hcRate×40%) — healthcare tends to
+            // escalate faster than CPI but also varies year to year
+            const hcSigma = Math.max(0.01, yearHcInflationRate * 0.4);
+            const [uh1, uh2] = [Math.max(1e-10, Math.random()), Math.random()];
+            const zh = Math.sqrt(-2 * Math.log(uh1)) * Math.cos(2 * Math.PI * uh2);
+            yearHcInflationRate = Math.max(0.001, yearHcInflationRate + zh * hcSigma);
+
+            // Property growth: σ = max(3%, rate×60%) — property cycles drive large swings
+            const propBase = inputs.propertyGrowthRate || 0.058;
+            const propSigma = Math.max(0.03, Math.abs(propBase) * 0.6);
+            const [up1, up2] = [Math.max(1e-10, Math.random()), Math.random()];
+            const zp = Math.sqrt(-2 * Math.log(up1)) * Math.cos(2 * Math.PI * up2);
+            yearPropertyGrowthRate = Math.max(-0.15, propBase + zp * propSigma);
+        }
+
+        // Stochastic shocks (applied on top of per-year rates drawn above)
+        currentInflation = useStochasticReturns
+            ? yearInflationRate // continuous variation already captured above
+            : applyInflationShock(inflation, inputs);
         const { newValue: investAfterShock, shockOccurred: investShock } =
             applyMarketShock(investmentAssets, inputs);
         if (investShock) investmentAssets = investAfterShock;
@@ -231,7 +264,9 @@ export const runLifeSimulation = (userInputs) => {
         }
 
         // ── Expenses ──────────────────────────────────────────────────────────
-        healthcareCosts = projectHealthcareCosts(healthcareCosts, age, inputs);
+        // Pass the per-year drawn healthcare inflation so each year compounds
+        // at a freshly sampled rate rather than the same fixed median value.
+        healthcareCosts = projectHealthcareCosts(healthcareCosts, age, inputs, yearHcInflationRate);
         state.healthcareCosts = healthcareCosts;
 
         const agedCare = getAgedCareCost(age, inputs) + (state.agedCareCosts || 0);
@@ -240,8 +275,9 @@ export const runLifeSimulation = (userInputs) => {
         const eduCosts = state.educationCosts || 0;
 
         if (age < retirementAge) {
-            // Pre-retirement: project living expenses from income
-            livingExpenses = projectLivingExpenses(livingExpenses, age, inputs);
+            // Pre-retirement: project living expenses using the per-year inflation draw
+            // so each year reflects a different inflation rate rather than a fixed compound.
+            livingExpenses = projectLivingExpenses(livingExpenses, age, inputs, yearInflationRate);
             state.livingExpenses = livingExpenses;
         } else {
             // ── Retirement spending ───────────────────────────────────────────
@@ -444,9 +480,10 @@ export const runLifeSimulation = (userInputs) => {
 
         investmentAssets = growInvestmentAssets(investmentAssets, annualNetContrib, yearInputs);
 
-        // Property value growth
+        // Property value growth — use the per-year stochastic draw so each year
+        // experiences a different growth rate rather than a fixed compound rate.
         if (propertyValue > 0) {
-            propertyValue = growPropertyValue(propertyValue, inputs);
+            propertyValue = growPropertyValue(propertyValue, inputs, yearPropertyGrowthRate);
         }
 
         // ── Finalise state snapshot ───────────────────────────────────────────

--- a/src/js/simulation_engine/life_simulation_engine.js
+++ b/src/js/simulation_engine/life_simulation_engine.js
@@ -140,6 +140,13 @@ export const runLifeSimulation = (userInputs) => {
     let previousPortfolio = 0;
     let propertyPurchasePrice = propertyValue; // track for CGT
 
+    // Cumulative inflation factor — built up as the product of each year's draw so
+    // that spending targets compound year-by-year rather than using a single bulk
+    // Math.pow(rate, years) formula.  In deterministic mode each year multiplies
+    // by the fixed median rate; in stochastic mode by a freshly drawn per-year rate.
+    let cumulativeInflationFactor = 1;
+    let cumulativeRetirementInflationFactor = 1; // restarted at retirement year
+
     // Healthcare costs
     let healthcareCosts = inputs.currentHealthcareCosts || 3500;
 
@@ -191,6 +198,22 @@ export const runLifeSimulation = (userInputs) => {
             yearPropertyGrowthRate = Math.max(-0.15, propBase + zp * propSigma);
         }
 
+        // Per-year salary growth draw — σ = max(0.5%, rate×40%) — wages vary year to
+        // year but not as widely as financial markets.
+        const salaryBase = inputs.salaryGrowthRate || 0.015;
+        let yearSalaryGrowthRate = salaryBase;
+        if (useStochasticReturns) {
+            const salSigma = Math.max(0.005, salaryBase * 0.4);
+            const [us1, us2] = [Math.max(1e-10, Math.random()), Math.random()];
+            const zs = Math.sqrt(-2 * Math.log(us1)) * Math.cos(2 * Math.PI * us2);
+            yearSalaryGrowthRate = Math.max(-0.05, salaryBase + zs * salSigma); // floor at -5%
+        }
+
+        // Accumulate cumulative inflation product — year-by-year multiplication so each
+        // year's drawn rate componds onto ALL prior years rather than being raised to a
+        // bulk power.  This is the correct way to handle stochastic per-year inflation.
+        cumulativeInflationFactor *= (1 + yearInflationRate);
+
         // Stochastic shocks (applied on top of per-year rates drawn above)
         currentInflation = useStochasticReturns
             ? yearInflationRate // continuous variation already captured above
@@ -225,11 +248,11 @@ export const runLifeSimulation = (userInputs) => {
         futurePropertyAnnualExpenses = state.futurePropertyExpenses || futurePropertyAnnualExpenses;
 
         // ── Income ────────────────────────────────────────────────────────────
-        salary        = projectSalary(salary, age, inputs);
+        salary        = projectSalary(salary, age, inputs, yearSalaryGrowthRate);
         partnerSalary = projectPartnerSalary(partnerSalary, partnerAge || age, {
             ...inputs,
             partnerRetirementAge: inputs.partnerRetirementAge || retirementAge,
-        });
+        }, yearSalaryGrowthRate);
 
         state.salary        = salary;
         state.partnerSalary = partnerSalary;
@@ -289,7 +312,16 @@ export const runLifeSimulation = (userInputs) => {
                 initialPortfolio = portfolioValue;
                 retirementWealth = portfolioValue;
                 currentSpending  = baseRetirementSpending;
+                // Reset retirement-phase cumulative factor; it seeds from the
+                // pre-retirement cumulative inflation so costs are continuous.
+                cumulativeRetirementInflationFactor = cumulativeInflationFactor;
             }
+
+            // Advance the retirement-phase cumulative factor with this year's draw.
+            // This correctly represents: baseCost × (1+i₁) × (1+i₂) × ... × (1+iₙ)
+            // rather than baseCost × (1 + fixedRate)^n, avoiding the bulk-power error
+            // that arises when a single randomly-drawn year's rate is exponentiated.
+            cumulativeRetirementInflationFactor *= (1 + yearInflationRate);
 
             currentSpending = calculateSpending({
                 strategy:          spendingStrategy,
@@ -299,6 +331,9 @@ export const runLifeSimulation = (userInputs) => {
                 initialSpending:   baseRetirementSpending,
                 yearsRetired,
                 inflation:         currentInflation,
+                // Pass the running cumulative factor so the FIXED strategy can apply
+                // the correct compound product rather than (single_rate)^years.
+                cumulativeInflationFactor: cumulativeRetirementInflationFactor,
                 portfolioDeclined,
                 inputs,
             });

--- a/src/js/simulation_engine/life_simulation_engine.js
+++ b/src/js/simulation_engine/life_simulation_engine.js
@@ -312,16 +312,12 @@ export const runLifeSimulation = (userInputs) => {
                 initialPortfolio = portfolioValue;
                 retirementWealth = portfolioValue;
                 currentSpending  = baseRetirementSpending;
-                // Reset retirement-phase cumulative factor; it seeds from the
-                // pre-retirement cumulative inflation so costs are continuous.
-                cumulativeRetirementInflationFactor = cumulativeInflationFactor;
+                // Retirement-phase cumulative factor starts at 1 (base spending is
+                // already in nominal dollars at retirement).  Pre-retirement inflation
+                // is NOT carried over here — the base spending is expressed in the
+                // nominal dollars of the retirement year, not simulation-start dollars.
+                cumulativeRetirementInflationFactor = 1;
             }
-
-            // Advance the retirement-phase cumulative factor with this year's draw.
-            // This correctly represents: baseCost × (1+i₁) × (1+i₂) × ... × (1+iₙ)
-            // rather than baseCost × (1 + fixedRate)^n, avoiding the bulk-power error
-            // that arises when a single randomly-drawn year's rate is exponentiated.
-            cumulativeRetirementInflationFactor *= (1 + yearInflationRate);
 
             currentSpending = calculateSpending({
                 strategy:          spendingStrategy,
@@ -331,12 +327,23 @@ export const runLifeSimulation = (userInputs) => {
                 initialSpending:   baseRetirementSpending,
                 yearsRetired,
                 inflation:         currentInflation,
-                // Pass the running cumulative factor so the FIXED strategy can apply
-                // the correct compound product rather than (single_rate)^years.
+                // Pass the running cumulative factor so the FIXED strategy applies
+                // the correct year-by-year compound product.  The factor is updated
+                // AFTER spending is calculated so that year 0 uses a factor of 1
+                // (matching the deterministic Math.pow(inf, 0) = 1 baseline).
                 cumulativeInflationFactor: cumulativeRetirementInflationFactor,
                 portfolioDeclined,
                 inputs,
             });
+
+            // Advance the retirement-phase cumulative factor AFTER spending is
+            // recorded.  This ensures:
+            //   yearsRetired=0: factor=1 → spending = base (no inflation yet) ✓
+            //   yearsRetired=1: factor=(1+i₁) → spending = base×(1+i₁) ✓
+            //   yearsRetired=n: factor=(1+i₁)×…×(1+iₙ) ✓
+            // Accumulating before spending would inflate year-0 spending by one
+            // extra year compared to the deterministic Math.pow baseline.
+            cumulativeRetirementInflationFactor *= (1 + yearInflationRate);
 
             state.livingExpenses = currentSpending;
             previousPortfolio    = portfolioValue;

--- a/src/js/simulation_engine/property_engine.js
+++ b/src/js/simulation_engine/property_engine.js
@@ -8,13 +8,35 @@
 /**
  * Grow investment property value by one year.
  *
+ * When useStochasticReturns is true, draws a per-year return from a normal
+ * distribution centred on propertyGrowthRate, giving each year a different
+ * growth rate instead of a fixed compound.  Property volatility defaults to
+ * 50% of the expected rate (e.g. 2.9% σ for a 5.8% base rate).
+ *
  * @param {number} currentValue        – current market value
  * @param {Object} inputs              – propertyGrowthRate, propertyCrashProbability (optional shock handled externally)
+ * @param {number} [yearGrowthRate]    – optional per-year override (stochastic mode)
  * @returns {number} new property value
  */
-export const growPropertyValue = (currentValue, inputs) => {
-    const { propertyGrowthRate = 0.058 } = inputs;
-    return currentValue * (1 + propertyGrowthRate);
+export const growPropertyValue = (currentValue, inputs, yearGrowthRate = null) => {
+    const { propertyGrowthRate = 0.058, useStochasticReturns = false } = inputs;
+
+    let effectiveRate;
+    if (yearGrowthRate !== null) {
+        effectiveRate = yearGrowthRate;
+    } else if (useStochasticReturns) {
+        // Per-year normal draw: σ = max(2%, rate×50%) to reflect realistic property cycles
+        const sigma = Math.max(0.02, Math.abs(propertyGrowthRate) * 0.5);
+        const u1 = Math.max(1e-10, Math.random());
+        const u2 = Math.random();
+        const z  = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+        // Floor at −15% (extreme property downturns, consistent with ABS RPPI data)
+        effectiveRate = Math.max(-0.15, propertyGrowthRate + z * sigma);
+    } else {
+        effectiveRate = propertyGrowthRate;
+    }
+
+    return currentValue * (1 + effectiveRate);
 };
 
 /**

--- a/src/js/simulation_engine/spending_engine.js
+++ b/src/js/simulation_engine/spending_engine.js
@@ -24,12 +24,28 @@ export const SPENDING_STRATEGIES = {
 /**
  * Inflation-adjusted fixed spending.
  *
- * @param {number} baseSpending  – initial retirement spending
- * @param {number} inflation     – annual inflation rate
- * @param {number} yearsRetired  – years since retirement
+ * In stochastic mode the caller passes the running cumulativeInflationFactor
+ * (the product of each year's independently drawn rate), which replaces the
+ * bulk Math.pow formula.  This ensures $100 of base spending compounds as
+ * $100 × (1+i₁) × (1+i₂) × … × (1+iₙ) rather than $100 × (1+iFixed)ⁿ.
+ *
+ * In deterministic mode cumulativeInflationFactor defaults to null and the
+ * original Math.pow formula is used unchanged.
+ *
+ * @param {number}      baseSpending              – initial retirement spending
+ * @param {number}      inflation                 – annual inflation rate (median)
+ * @param {number}      yearsRetired              – years since retirement
+ * @param {number|null} [cumulativeInflationFactor] – pre-computed cumulative product
  * @returns {number}
  */
-export const fixedSpending = (baseSpending, inflation, yearsRetired) => {
+export const fixedSpending = (baseSpending, inflation, yearsRetired, cumulativeInflationFactor = null) => {
+    if (cumulativeInflationFactor !== null) {
+        // Stochastic path: use the year-by-year accumulated product.
+        // The factor already includes compounding from all prior years, so we apply
+        // it directly — no further Math.pow needed.
+        return baseSpending * cumulativeInflationFactor;
+    }
+    // Deterministic path: single-rate compound (unchanged behaviour).
     return baseSpending * Math.pow(1 + inflation, yearsRetired);
 };
 
@@ -174,11 +190,12 @@ export const calculateSpending = ({
     yearsRetired       = 0,
     inflation          = 0.026,
     portfolioDeclined  = false,
+    cumulativeInflationFactor = null, // when provided, used by FIXED strategy instead of Math.pow
     inputs             = {},
 }) => {
     switch (strategy) {
         case SPENDING_STRATEGIES.FIXED:
-            return fixedSpending(initialSpending, inflation, yearsRetired);
+            return fixedSpending(initialSpending, inflation, yearsRetired, cumulativeInflationFactor);
 
         case SPENDING_STRATEGIES.GUARDRAILS:
             return guardrailSpending(currentSpending, portfolioValue, initialPortfolio, {

--- a/src/js/simulation_engine/super_engine.js
+++ b/src/js/simulation_engine/super_engine.js
@@ -53,10 +53,25 @@ export const calcSuperContributions = (grossSalary, age, inputs, calendarYear = 
  * @param {Object} inputs             – superReturn
  * @returns {number} end-of-year balance
  */
-export const growSuperBalance = (currentBalance, contributions, superTax, inputs) => {
-    const { superReturn = 0.075 } = inputs;
+export const growSuperBalance = (currentBalance, contributions, superTax, inputs, yearSuperReturn = null) => {
+    const { superReturn = 0.075, useStochasticReturns = false } = inputs;
     const netContributions = contributions - superTax;
-    return (currentBalance + netContributions) * (1 + superReturn);
+
+    let effectiveReturn;
+    if (yearSuperReturn !== null) {
+        effectiveReturn = yearSuperReturn;
+    } else if (useStochasticReturns) {
+        // Per-year normal draw for super: σ = max(3%, rate×60%) reflects balanced-fund volatility
+        const sigma = Math.max(0.03, Math.abs(superReturn) * 0.6);
+        const u1 = Math.max(1e-10, Math.random());
+        const u2 = Math.random();
+        const z  = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+        effectiveReturn = Math.max(-0.30, superReturn + z * sigma); // super funds can lose up to 30%
+    } else {
+        effectiveReturn = superReturn;
+    }
+
+    return (currentBalance + netContributions) * (1 + effectiveReturn);
 };
 
 /**

--- a/src/js/simulator.js
+++ b/src/js/simulator.js
@@ -64,16 +64,25 @@ const resolveScenarioMonteCarloRuns = (inputs = {}) =>
  * Backward-compat: two-arg legacy call stochasticRate(rate, floor) is detected when
  * the second argument is a number, and treated as stochasticRate(rate, true, floor).
  */
-export function stochasticRate(centralRate, isStochastic = true, floor = 0) {
+export function stochasticRate(centralRate, isStochastic = true, floor = 0, sigma = null) {
     if (typeof isStochastic === 'number') {
         // Legacy two-argument call: stochasticRate(centralRate, floor)
         floor = isStochastic;
         isStochastic = true;
     }
     if (!isStochastic) return centralRate;
-    // Symmetric uniform draw: perturbation ∈ [-0.04, +0.04], E[perturbation] = 0
-    const perturbation = (Math.random() - 0.5) * 0.08; // 0.08 = 2 × 0.04
-    return Math.max(floor, centralRate + perturbation);
+    // Normal distribution via Box-Muller transform.
+    // Default sigma provides realistic year-to-year variation:
+    //   - Large rates (e.g. 7.5% super return): wider absolute swings
+    //   - Small rates (e.g. 1.4% savings): narrower swings
+    // sigma=null → use rate-proportional volatility: max(1%, |rate|×50%)
+    // This replaces the old uniform [-4%,+4%] with a fat-tailed normal that
+    // better represents real economic variability across successive years.
+    const effectiveSigma = sigma !== null ? sigma : Math.max(0.01, Math.abs(centralRate) * 0.5);
+    const u1 = Math.max(1e-10, Math.random());
+    const u2 = Math.random();
+    const z  = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+    return Math.max(floor, centralRate + z * effectiveSigma);
 }
 
 export class RetirementSimulator {

--- a/src/js/simulator.js
+++ b/src/js/simulator.js
@@ -1033,7 +1033,8 @@ export class RetirementSimulator {
     getSalaryForYear(baseSalary, year, inputs, isPartner = false, overrideInflationRate = null, overrideSalaryGrowthRate = null) {
         const yearsToRetirement = inputs.retirementAge - inputs.yourCurrentAge;
         const inflationRate = overrideInflationRate ?? inputs.inflation;
-        
+        const currentAge = (isPartner ? inputs.partnerCurrentAge : inputs.yourCurrentAge) + year;
+
         let realGrowthRate = overrideSalaryGrowthRate ?? inputs.salaryGrowthRate;
 
         // Structured Salary Growth Types
@@ -1050,6 +1051,21 @@ export class RetirementSimulator {
             }
         }
         // 'standard' keeps pace with CPI + user specified real growth
+
+        // Age-based ageism adjustment: salary growth slows in later career due to
+        // discrimination, health factors, and reduced advancement opportunities.
+        const ageismStartAge = inputs.ageismStartAge ?? 50;
+        const retirementAge = isPartner ? (inputs.partnerRetirementAge ?? 65) : (inputs.retirementAge ?? 65);
+        if (currentAge >= ageismStartAge && currentAge < retirementAge) {
+            const yearsAfterAgeism = currentAge - ageismStartAge;
+            if (yearsAfterAgeism < 3) {
+                // Static phase: near-zero growth for first 3 years after ageism onset
+                realGrowthRate = Math.min(realGrowthRate, 0.0);
+            } else {
+                // Recovery phase: modest growth resumes at max 0.5% real
+                realGrowthRate = Math.min(realGrowthRate, 0.005);
+            }
+        }
 
         let salary = baseSalary * Math.pow(1 + realGrowthRate + inflationRate, year);
 

--- a/src/js/simulator.js
+++ b/src/js/simulator.js
@@ -1052,17 +1052,21 @@ export class RetirementSimulator {
         }
         // 'standard' keeps pace with CPI + user specified real growth
 
-        // Age-based ageism adjustment: salary growth slows in later career due to
-        // discrimination, health factors, and reduced advancement opportunities.
+        // Age-based ageism (opt-in via inputs.enableAgeism).
+        // Models late-career salary stagnation from age discrimination, reduced
+        // promotions, and health factors.  realGrowthRate here is the REAL component
+        // (inflation is added separately via inflationRate), so:
+        //   - Capping at 0.0 real = salary keeps pace with CPI only (real stagnation)
+        //   - Capping at 0.5% real = slight real growth, still well below typical career
         const ageismStartAge = inputs.ageismStartAge ?? 50;
-        const retirementAge = isPartner ? (inputs.partnerRetirementAge ?? 65) : (inputs.retirementAge ?? 65);
-        if (currentAge >= ageismStartAge && currentAge < retirementAge) {
+        const retirementAge  = isPartner ? (inputs.partnerRetirementAge ?? 65) : (inputs.retirementAge ?? 65);
+        if (inputs.enableAgeism && currentAge >= ageismStartAge && currentAge < retirementAge) {
             const yearsAfterAgeism = currentAge - ageismStartAge;
             if (yearsAfterAgeism < 3) {
-                // Static phase: near-zero growth for first 3 years after ageism onset
+                // Static real phase: salary grows only with inflation (no real gain)
                 realGrowthRate = Math.min(realGrowthRate, 0.0);
             } else {
-                // Recovery phase: modest growth resumes at max 0.5% real
+                // Modest recovery: up to 0.5% real growth above inflation
                 realGrowthRate = Math.min(realGrowthRate, 0.005);
             }
         }

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1902,19 +1902,19 @@ export const exportToPDF = (inputs, results, chartManager, app = null) => {
 
     const lifestyleStatus = results.finalBalance > 0 ? 'Affordable' : 'Tight';
     const lifestyleYears = results.depletionAge ? `until age ${results.depletionAge}` : `for full lifespan`;
-    drawBottomLineItem("⛵", "Lifestyle Goals", `${lifestyleStatus}: Your plan sustains your ${formatCurrency(inputs.asfaComfortable)} lifestyle ${lifestyleYears}.`);
+    drawBottomLineItem("[Goals]", "Lifestyle Goals", `${lifestyleStatus}: Your plan sustains your ${formatCurrency(inputs.asfaComfortable)} lifestyle ${lifestyleYears}.`);
 
     const hasBuffer = (results.accumulatedSavingsBalance > inputs.asfaComfortable * 0.5);
     const crashText = hasBuffer
         ? `Resilient: You have a ${formatCurrency(results.accumulatedSavingsBalance)} cash buffer to weather market volatility.`
         : `Exposure: Low cash reserves mean you may be forced to sell assets during a market downturn.`;
-    drawBottomLineItem("🛡️", "Crash Safety Net", crashText);
+    drawBottomLineItem("[Safety]", "Crash Safety Net", crashText);
 
     const startPensionYear = results.yearlyData.find(y => y.pensionIncome > 0);
     const pensionText = startPensionYear
         ? `Hybrid: You transition to a part-pension at age ${startPensionYear.age}, extending your portfolio's life.`
         : `Self-Funded: You remain above the asset test cutoff for the projected period.`;
-    drawBottomLineItem("🏛️", "Pension Transition", pensionText);
+    drawBottomLineItem("[Pension]", "Pension Transition", pensionText);
 
     // --- Table of Contents ---
     doc.addPage();


### PR DESCRIPTION
## Summary

This PR implements four major improvements across all three calculator pipelines (A: simulator.js, B: life_simulation_engine, C: advanced-design-engine), plus PDF export fixes.

### 1. Per-year stochastic rates (non-linear growth)

Previously all calculators applied a single fixed growth rate compounded across all years (`balance × (1+rate)^n`). Each year now draws an independent rate from a normal distribution (Box-Muller transform), so no two years share the same growth assumption.

- **Pipeline A** (`simulator.js`): `stochasticRate()` replaced uniform ±4pp draw with normal distribution; sigma defaults to `max(1%, |rate|×50%)` per asset class
- **Pipeline B** (`life_simulation_engine.js`): per-year draws at the top of each year loop for inflation (σ=max(0.5%, rate×40%)), healthcare inflation (σ=max(1%, rate×40%)), property growth (σ=max(3%, rate×60%), floor -15%), salary growth (σ=max(0.5%, rate×40%), floor -5%)
- **Pipeline C** (`advanced-design-engine.js`): full Monte Carlo (500 runs by default) added; each run draws per-year rates for super (σ=max(3%, rate×60%)), savings (σ=max(0.5%, rate×30%)), inflation (σ=max(0.5%, rate×40%))
- Sub-engines (`super_engine`, `investment_engine`, `property_engine`, `expense_engine`, `income_engine`): all accept an optional `yearXxxReturn` override so the caller controls per-year randomness; fall back to inline stochastic draw or deterministic median when not provided

### 2. Median output (not average)

- Pipeline C now runs 500 MC paths and reports the **median** outcome (p50), sorted by `annualRetirementIncome` so the returned result is a self-consistent single simulation run — all fields come from the same path
- `successRate`, `p10Income`, `p90Income` are also returned for display
- `calculateSensitivity()` switches to `calculateDeterministic()` for clean delta comparisons (MC variance would obscure small parameter differences)

### 3. Cumulative inflation factor — correct compound formula

**Bug fixed**: `fixedSpending()` was using `Math.pow(singleYearDraw, N)` which exponentiates one randomly-drawn year's rate over all N years.

Fix: `life_simulation_engine.js` now maintains a `cumulativeRetirementInflationFactor` built up as `× (1+i₁) × (1+i₂) × … × (1+iₙ)` and passes it to `calculateSpending`. The factor:
- Initialises to **1** at retirement start (base spending is in nominal dollars at retirement — pre-retirement CPI is NOT carried over)
- Accumulates **after** spending is calculated each year (avoids off-by-one where year-0 spending would include one extra year of inflation)

### 4. Nominal vs real values

Savings balances show **nominal** amounts (what you actually have), not purchasing-power-adjusted amounts. Expenses grow at the inflation rate. "Real terms" is a user-controlled display toggle only, not applied to balances.

### 5. Salary ageism modelling (opt-in)

Models late-career salary stagnation from age discrimination, reduced advancement, and health factors. Activated via `inputs.enableAgeism = true`.

- **First 3 years** after `inputs.ageismStartAge` (default 50): no growth
- **After 3 years**: growth capped at modest levels
- Pipeline A (`getSalaryForYear`): caps **real** growth rate at 0% / 0.5% — salary still keeps pace with inflation during static phase
- Pipeline B (`projectSalary`): caps **nominal** growth rate at 0% / 0.5% — real purchasing power declines during static phase (stronger effect)
- Both distinctions are documented in comments

### 6. PDF generation fixes

- **Emoji removal** (`utils.js`): jsPDF built-in fonts (Helvetica/Times/Courier) are Latin-1 only; emoji characters (⛵ 🛡️ 🏛️) produced corrupt/garbled output. Replaced with plain ASCII labels `[Goals]`, `[Safety]`, `[Pension]`
- **Argument order bug** (`advanced-v2.js` `exportSuggestionsAsPdf`): suggestions data was passed as the 3rd argument (chartManager) instead of the 4th (app bridge), so charts broke and suggestions section was never populated. Fixed to pass `APP_STATE.chartManager` as 3rd and the bridge as 4th
- **Missing suggestions in export bridge**: added `currentSuggestions` to `buildExportAppBridge()` so both the standard PDF button and the Suggestions & Action Plan PDF export include recommendations

## Commits

| # | Commit | What |
|---|--------|------|
| 1 | `03f92f3` | Per-year stochastic rates across all calculators with median output |
| 2 | `72de978` | Correct cumulative inflation compounding and stochastic salary growth |
| 3 | `db3c3a7` | Ageism salary model + PDF emoji/argument fixes |
| 4 | `2439976` | **Fix**: correct cumulative retirement inflation factor seeding and ordering |
| 5 | `b555aee` | **Fix**: make ageism opt-in; reconcile nominal vs real rate distinction |
| 6 | `1f35d67` | **Fix**: use median-income run as MC representative result (self-consistent) |

## Test plan

- [x] Run advanced-v2 calculator with 50+ year old inputs, verify salary projection shows ageism effect only when `enableAgeism` is checked
- [x] Run advanced-v2 Monte Carlo; verify result shows successRate, p10Income, p90Income in the MC stats panel
- [x] Verify savings balance after 10 years at 10% interest shows ~$270 (not ~$151 purchasing-power value)
- [x] Export PDF from advanced-v2 — verify no garbled characters in the Bottom Line section
- [x] Export PDF from Suggestions & Action Plan tab — verify recommendations appear in the PDF and charts render
- [x] Run deterministic and stochastic modes; verify spending in retirement year 0 = base spending (no extra inflation applied)
- [x] Run sensitivity analysis; verify small parameter changes produce clean non-noisy deltas
