### PR TITLE
feat(reverse): calculator consolidation — scenario builder, solver fixes, regression tests

### DIFF
--- a/docs/consolidated_fixes_updates.md
+++ b/docs/consolidated_fixes_updates.md
@@ -1,0 +1,1020 @@
+# 📘 Consolidation Summary & PR Review Context (Formatted Markdown)
+
+## 1. Primary Requests & Intent
+
+### **Request 1 — Complete Remaining Calculator Consolidation Fixes**
+The user asked to review the consolidation implementation described in:
+
+- `docs/calculator_consolidation_agent_prompt.md`
+- `docs/calculator_consolidation_analysis.md`
+
+They had already implemented:
+
+- Stochastic rate defects fix  
+- Safe engine bridge (`ProjectionService`)  
+- Advanced‑v2 migration with opt‑in cashflow  
+- Canonical normalization idempotency fix  
+- Classic advanced migration through `ProjectionService`  
+- Reverse planner single‑projection‑source migration  
+- Reverse manual mode using one projection object  
+- `solveForCurrentInvestmentBalance` restored to `solveAllLevers`  
+- Scenario Builder UI/engine  
+
+Remaining items were to be completed.
+
+---
+
+### **Request 2 — Reverify All Work**
+The user asked to:
+
+- Re‑audit all previous updates  
+- Identify mistakes, missing steps, unsupported assumptions, invented details  
+- Rewrite updates more carefully  
+- Provide confidence ratings (1–10)  
+- Commit fixes separately  
+- Create a PR to merge to master  
+
+---
+
+### **Request 3 — Review PR #100**
+The user asked to run a code review on PR #100 using the `/code-review` skill.
+
+---
+
+## 2. Key Technical Concepts
+
+### **Australian Retirement Calculator**
+- Browser‑only static site  
+- All computation in JavaScript  
+
+### **Three Calculation Pipelines**
+1. **Pipeline A** — `simulator.js` / `RetirementSimulator` (used by `advanced.html`)  
+2. **Pipeline B** — `life_simulation_engine.js` (used by `advanced-v2.html`)  
+3. **Pipeline C** — `advanced-design-engine.js`  
+
+### **Consolidation Architecture**
+- Canonical input schema  
+- Input adapters  
+- Household cashflow engine  
+- `ProjectionService`  
+- `RetirementSimulator`  
+- Shared result/PDF/reverse  
+
+### **ProjectionService**
+- Normalises once  
+- Builds engine inputs once  
+- Deterministic simulation  
+- Caches by FNV‑1a hash  
+
+### **Household Cashflow Engine**
+- Surplus = post‑tax income − spending − mortgage − explicit contributions  
+- Allocation modes: cash / invest / mortgage_first / super_first / custom_split  
+- Warnings for missing or zero spending  
+
+### **ReverseScenarioEngine**
+- 10 comparison paths  
+- Calls `ReverseRetirementSolver.solveAllLevers()`  
+- Produces required salary/super/savings outputs  
+
+### **Bisection Solvers**
+- `solveForCurrentInvestmentBalance`  
+- `solveForCurrentSuperBalance`  
+- `solveForSalary`  
+- `solveForExtraAnnualSuper`  
+- `solveForExtraSavings`  
+- `solveForNetRent`  
+- `solveForRetirementAge`  
+
+### **Stochastic Sigma by Asset Class**
+- Inflation/healthcare: 40%  
+- Salary/savings: 30%  
+- Super: 60% (floor −30%)  
+
+### **Nominal vs Real**
+- Savings always nominal  
+- Real‑terms toggle is display‑only  
+
+### **Input Hash**
+- FNV‑1a over canonical input + raw input + policy version  
+
+### **Tech Stack**
+- ES2020 modules  
+- Webpack 5  
+- Tailwind CSS  
+- Chart.js  
+- jsPDF 3.x  
+- Jest  
+
+### **Australian Rules 2025–26**
+- SG 12%  
+- Concessional cap $30k  
+- Non‑concessional $120k  
+- Transfer Balance Cap $2M  
+- Div 293 threshold $250k  
+
+---
+
+## 3. Files & Code Sections
+
+### **`reverse-solver.js`**
+Fix: `solveForCurrentInvestmentBalance()` was implemented but never called.
+
+```js
+investmentBalResult,   // added
+solveForCurrentInvestmentBalance(...),  // added
+```
+
+---
+
+### **`reverse-planner.js`**
+Added missing partner fields:
+
+```js
+partnerCurrentAge: ...
+partnerRetirementAge: ...
+partnerLifespan: ...
+```
+
+---
+
+### **`reverse-scenario-engine.js`**
+New file implementing:
+
+- Scenario definitions  
+- Scenario application  
+- Solver mapping  
+- 10 scenario paths  
+
+---
+
+### **`reverse.html`**
+Added Scenario Builder section:
+
+- 9 input fields  
+- 8 toggles  
+- 11‑column results table  
+
+---
+
+### **`reverse-ui.js`**
+Enhancements:
+
+- Imported `ReverseScenarioEngine`  
+- Added XSS‑safe `escapeHtml()`  
+- Added scenario builder logic  
+- Added PDF export integration  
+
+---
+
+### **Unit Tests**
+- Added tests for `solveAllLevers`  
+- Added 10 tests for `ReverseScenarioEngine`  
+
+---
+
+## 4. Errors & Fixes Identified
+
+### **XSS Escape Fix**
+`scenario.scenarioName` was unescaped in HTML injection.  
+Fixed by wrapping with `escapeHtml()`.
+
+---
+
+### **Missing Test for Investment Balance Solver**
+Added regression tests ensuring:
+
+- `investmentBalance` is included  
+- All lever types present  
+- `currentScore` and `currentResult` returned  
+
+---
+
+## 5. Problem Solving Summary
+
+- All **1122** existing tests passed  
+- Added **10** new tests → total **1132**  
+- Build compiles cleanly  
+- PR #100 created with structured commits  
+
+---
+
+## 6. Verified Items During Re‑Audit
+
+- Asset thresholds confirmed  
+- Mock simulator compatibility validated  
+- `applyTargetToEngineInputs` preserves `sellPropertyYears`  
+- `adaptReverseManualInput` handles dual field names correctly  
+
+---
+
+## 7. All User Messages (Condensed)
+
+1. Implement remaining consolidation fixes  
+2. Pause + reverify + rewrite + confidence ratings + commit + PR  
+3. Review PR  
+
+---
+
+## 8. Pending Tasks
+
+- Complete PR #100 code review  
+- Multi‑angle analysis was in progress when interrupted  
+
+---
+
+## 9. Current Work
+
+The `/code-review` skill had fetched the 2773‑line diff and was entering analysis phases when the summary request interrupted it.
+
+  Summary
+
+  3 correctness bugs that affect calculation output:
+  - Salary sigma 0.3 → should be 0.4 — Pipeline A MC underestimates salary variance by 25% vs spec.
+  - Checkbox null-coercion — reverse planner scenario toggles unreliable when section is absent/not-yet-rendered.
+  - noCurrentAssets leaves cashflow injections live — "salary only" scenario receives hidden $X/yr surplus, understating required salary.
+
+  2 data-integrity bugs in new infrastructure:
+  - mortgage_first unit mismatch — lump-sum balance treated as annual repayment capacity.
+  - Dead fallback for imported zero-spend projections — silent $0 spending base after import.
+
+  1 test fragility (removed Math.random pin without useStochasticReturns guards).
+
+  4 cleanup/efficiency findings: sequential scenario solves (10× slower than needed), escapeHtml duplication with diverging implementations, unbounded
+  projection cache, super_first concessional-cap double-count risk.
+
+  The three correctness bugs and the two data bugs are the most important to address before merge. The salary sigma is also a CLAUDE.md convention violation
+  (documented spec in §Stochastic Rate Model).
+
+---------------------------------------------------------
+
+Summary:
+     1. Primary Request and Intent:
+
+     **Request 1:** The user asked to look through a calculator consolidation implementation (described in `docs/calculator_consolidation_agent_prompt.md`
+     and `docs/calculator_consolidation_analysis.md`) and complete remaining fixes. They had already implemented: stochastic rate defects fix, safe engine
+     bridge (ProjectionService), advanced-v2 migration with opt-in cashflow, canonical normalization idempotency fix, classic advanced migration through
+     ProjectionService, reverse planner single-projection-source migration, reverse manual mode using one projection object,
+     `solveForCurrentInvestmentBalance` restored to `solveAllLevers`, and Scenario Builder UI/engine. They wanted the remaining items completed.
+
+     **Request 2:** "Pause and reverify all the work completed. I believe there may be a glitch or you have missed some information. Please go through and
+     review your previous updates and implementations for: mistakes, missing steps, unsupported assumptions and invented details. Then rewrite the updates
+     and implementations more carefully and give a confidence rating from 1-10 for each. Then separately commit the various fixes done, and create a PR for
+     the branch to merge to master."
+
+     **Request 3:** "review the PR" — asking to run a code review on PR #100 using the `/code-review` skill.
+
+     2. Key Technical Concepts:
+
+     - **Australian Retirement Calculator** — browser-only static site, no backend, all computation in JavaScript
+     - **Three calculation pipelines**: Pipeline A (`simulator.js`/`RetirementSimulator` used by `advanced.html`), Pipeline B (`life_simulation_engine.js`
+     used by `advanced-v2.html`), Pipeline C (`advanced-design-engine.js`)
+     - **Calculator consolidation architecture**: canonical input schema → input adapters → household cashflow engine → ProjectionService →
+     RetirementSimulator → shared result/PDF/reverse
+     - **ProjectionService**: normalises once, builds engine inputs once, runs deterministic simulation, caches by input hash (FNV-1a hash)
+     - **Household cashflow engine**: derives surplus = post-tax income - spending - mortgage - explicit contributions; allocates via surplusAllocationMode
+     (cash/invest/mortgage_first/super_first/custom_split)
+     - **ReverseScenarioEngine**: 10 comparison paths per household, calls `ReverseRetirementSolver.solveAllLevers()` per scenario, maps lever results to
+     required-salary/super/savings output columns
+     - **Bisection solvers**: `solveForCurrentInvestmentBalance`, `solveForCurrentSuperBalance`, `solveForSalary`, `solveForExtraAnnualSuper`,
+     `solveForExtraSavings`, `solveForNetRent`, `solveForRetirementAge`
+     - **Stochastic sigma by asset class**: type-specific via `stochasticSigmaForRate(rate, type)` — inflation/healthcare at 40%, salary/savings at 30%,
+     super at 60%, super floor now -30% not 0%
+     - **Nominal vs real values**: savings balances always nominal; real-terms toggle is display-only
+     - **Input hash**: FNV-1a hash over stable-stringified canonical input + raw input + policy version
+     - **Tech stack**: ES2020 modules, webpack 5, Tailwind CSS (CDN), Chart.js, jsPDF 3.x, Jest
+     - **Australian financial rules 2025-26**: SG 12%, concessional cap $30k, non-concessional $120k, Transfer Balance Cap $2M, Division 293 threshold $250k
+
+     3. Files and Code Sections:
+
+     - **`src/js/reverse-solver.js`** (modified, committed in fix commit 8ef90cc)
+       - Added `investmentBalResult` to the `solveAllLevers` destructuring and `Promise.all()` array and `allLevers` array
+       - Pre-existing omission: `solveForCurrentInvestmentBalance()` was fully implemented but never called in `solveAllLevers()`
+       ```js
+       const [
+           extraSuperResult,
+           salaryResult,
+           retireAgeResult,
+           superBalResult,
+           investmentBalResult,   // ← added
+           extraSavingsResult,
+           netRentResult,
+       ] = await Promise.all([
+           solveForExtraAnnualSuper(...),
+           solveForSalary(...),
+           solveForRetirementAge(...),
+           solveForCurrentSuperBalance(...),
+           solveForCurrentInvestmentBalance(...),  // ← added
+           solveForExtraSavings(...),
+           solveForNetRent(...),
+       ]);
+       ```
+
+     - **`src/js/reverse-planner.js`** (modified, committed in fix commit 8ef90cc)
+       - Added missing couple fields to `normaliseReversePlannerInputs()`:
+       ```js
+       partnerCurrentAge: isCouple ? num(rawInputs.partnerAge ?? rawInputs.partnerCurrentAge, 50) : 0,
+       partnerRetirementAge: isCouple ? num(rawInputs.partnerRetirementAge ?? rawInputs.retirementAge, 67) : 0,
+       partnerLifespan: isCouple ? num(rawInputs.partnerLifespan ?? rawInputs.lifespan ?? rawInputs.yourLifespan, 90) : 0,
+       ```
+
+     - **`src/js/calculation/reverse-scenario-engine.js`** (new, committed in feat commit ecee859)
+       - `ReverseScenarioEngine` class with `buildScenarioDefinitions(selected)`, `applyScenario(baseEngineInputs, target, scenario)`, `solveScenario(...)`,
+     `compareScenarios(...)`
+       - 10 comparison paths: `selected`, `home_super_pension`, `home_super_private`, `renter_super_pension`, `non_super_only`, `property_retained`,
+     `property_sold`, `salary_only`, `aged_care`, `stress`
+       - `applyScenario` adjusts engine inputs based on toggles: zeroes super when `includeSuper:false`, sets `pensionAssetThreshold` based on
+     homeowner/renter status using `this.config.COUPLE_ASSET_THRESHOLD_NON_HOMEOWNER` etc., sets `sellPropertyYears` for property-sold scenario, applies
+     stress return/inflation deltas
+       - Returns: `requiredCurrentSuper`, `requiredCurrentNonSuperInvestments`, `requiredCurrentGrossSalary`, `requiredMonthlySurplus`,
+     `requiredAnnualSalarySacrifice`, `expectedAgePensionContribution`, `expectedAssetsAtRetirement`, `expectedEstateAtLifespan`, `meetsGoal`, `warnings`
+
+     - **`src/reverse.html`** (modified, committed in feat commit ecee859)
+       - Added new `<section>` with id `rsb-section` above the existing planner sections
+       - 9 input fields: household, rsb-age, rsb-partner-age, rsb-retirement-age, rsb-target-income (default $84,000), rsb-confidence (select 70/80/90%),
+     rsb-lifespan, rsb-home-status, rsb-primary-rent
+       - 8 toggle checkboxes: rsb-include-super (checked), rsb-include-pension (checked), rsb-include-non-super (checked), rsb-include-property,
+     rsb-sell-property, rsb-include-downsizing, rsb-include-aged-care, rsb-include-overseas
+       - Results table with 11 columns: Scenario, Current super needed, Non-super needed, Gross salary needed, Monthly surplus, Salary sacrifice,
+     Property/rent, Age Pension, Assets at retirement, Estate, Warnings
+       - `<tbody id="rsb-results-body">` dynamically filled
+
+     - **`src/js/reverse-ui.js`** (modified, committed in feat commit ecee859; escaping fix included)
+       - Added `import { ReverseScenarioEngine } from './calculation/reverse-scenario-engine.js'`
+       - Added `escapeHtml(value)` helper function for XSS defense
+       - Added `this.scenarioEngine = new ReverseScenarioEngine(ENHANCED_CONFIG)` in constructor
+       - Added `handleScenarioBuilder()`: reads `projectionInput` + `target` + `selected` via `collectScenarioBuilderInputs()`, calls
+     `this.planner.projectionService.computeProjection()`, then `this.scenarioEngine.compareScenarios()`, stores `scenarioBuilderResults` with `inputHash`
+       - Added `collectScenarioBuilderInputs()`: reads rsb-* element IDs, merges `this.forwardProjection?.engineInputs ||
+     this.lastResult?.projection?.engineInputs || {}`
+       - Added `renderScenarioBuilderResults(scenarioSet)`: builds table rows with `escapeHtml(scenario.scenarioName)` (fix applied during review)
+       - PDF export: scenario builder section with `autoTable` of 7 columns + deduplicated warnings via `infoBox`
+
+     - **`tests/unit/reverse-solver.test.js`** (modified, committed in test commit fd25b32)
+       - Added `ReverseRetirementSolver` to imports
+       - Added `describe('ReverseRetirementSolver.solveAllLevers', ...)` block with 3 tests:
+         - `'includes investmentBalance in rankedLevers — regression for previously omitted solver'`
+         - `'includes all expected lever types in output'` (checks extraAnnualSuper, extraSavings, salary, retirementAge, superBalance, investmentBalance)
+         - `'returns currentScore and currentResult alongside rankedLevers'`
+
+     - **`tests/unit/reverse-scenario-engine.test.js`** (new, committed in test commit fd25b32)
+       - 10 tests in `describe('ReverseScenarioEngine', ...)`
+       - Tests: scenario count (10), $84k couple paths present, Age Pension/renter toggles, super-off zeroes balances, noCurrentAssets zeroes all,
+     property-retained preserves values (no `sellPropertyYears`), property-sold sets `sellPropertyYears > 0`, aged-care-on sets defaults, aged-care-off
+     zeroes cost, stress reduces returns and raises inflation, solver output column mapping
+
+     - **`src/js/calculation/projection-service.js`** (existing, read for verification)
+       - `ProjectionService` class: adapter → canonical input → cashflow derivation → `normaliseInputs(engineInputBuilder(...))` → `simulateRetirement` →
+     cache by FNV-1a hash
+       - Returns full projection: `{ inputHash, policyVersion, schemaVersion, sourceCalculator, canonicalInput, derivedCashflow, engineInputs, simulation,
+     adaptedResult, yearlyData, summary, diagnostics, warnings }`
+
+     - **`src/js/calculation/household-cashflow-engine.js`** (existing, read for verification)
+       - `deriveHouseholdCashflow(canonicalInput)`: returns `{ monthlySurplus, annualSurplus, allocations: {cash, stocks, super, mortgage}, allocatedSurplus,
+     unallocatedSurplus, warnings, canAllocateSurplus }`
+       - Guards: `canAllocateSurplus = cashflow.hasDetailedExpenses && currentAnnualSpending > 0`
+       - Warning when spending missing: `'Current household spending is missing, so no implicit surplus was allocated.'`
+       - Warning when spending zero: `'Current household spending must be greater than zero before surplus can be allocated.'`
+
+     - **`src/js/calculation/canonical-input-schema.js`** (existing, read for verification)
+       - `normaliseCanonicalInput(input)` with full schema: household, income, currentAssets, cashflow, retirementTarget, housingAndPension, scenarioToggles,
+     assumptions
+       - Returns `{ schemaVersion: 'calculator-input-v1', ... }`
+
+     - **`src/js/calculation/input-adapters/reverse-manual-adapter.js`** (existing, read for verification)
+       - `adaptReverseManualInput(input)`: handles dual field names like `input.currentAge ?? input.yourCurrentAge`, `input.annualSalary ??
+     input.yourSalary`, etc.
+
+     - **`src/js/simulator.js`** (existing, read for verification of stochastic fixes)
+       - `stochasticSigmaForRate(centralRate, rateType)`: type-specific sigma with settings for inflation/healthcare/salary/super/savings/generic
+       - Super now uses floor `-0.30` (was `0`): `stochasticRate(inputs.superReturn, useRandomReturns, -0.30, stochasticSigmaForRate(...))`
+       - Per-run inflation uses `effectiveInputs.inflation` (scenario-adjusted), not raw `inputs.inflation`
+
+     4. Errors and Fixes:
+
+     - **`scenario.scenarioName` unescaped in `renderScenarioBuilderResults`**: Found during the reverify audit. The scenario name was injected directly into
+     `innerHTML` as `<strong>${scenario.scenarioName}</strong>` while warnings correctly used `escapeHtml()`. Fixed by changing to
+     `<strong>${escapeHtml(scenario.scenarioName)}</strong>`. Names are hardcoded so not a real XSS vector, but inconsistent with the existing escaping
+     pattern and violates defense-in-depth.
+
+     - **No test for `solveAllLevers` including `investmentBalance`**: The key regression gap for the solver fix. Added `ReverseRetirementSolver` to imports
+     and a new `describe` block in `reverse-solver.test.js`. Tests use the existing jest mock for `simulator.js` and `config.js`.
+
+     5. Problem Solving:
+
+     **Solved:**
+     - All 1122 pre-existing tests continued to pass throughout
+     - After adding 10 new tests, total is 1132 passing across 55 suites
+     - Build (`npm run build`) compiles all three webpack bundles without errors
+     - Three logical commits organized by concern (fix/feat/test)
+     - PR #100 created at https://github.com/gagneet/retirement_calculator_au/pull/100
+
+     **Verified items during reverify:**
+     - `COUPLE_ASSET_THRESHOLD_NON_HOMEOWNER` confirmed in `config.js` at line 43: `COUPLE_ASSET_THRESHOLD_NON_HOMEOWNER: 739500`
+     - Mock simulator compatibility: `solveForCurrentInvestmentBalance` varies `currentSavings`; mock uses `currentSavings` in its formula
+     - `applyTargetToEngineInputs` returns a spread that preserves `sellPropertyYears` when set (for sold scenario) or leaves it undefined (for retained
+     scenario)
+     - `adaptReverseManualInput` correctly handles engine-level field names from `baseEngineInputs` via dual-field lookups
+
+     6. All User Messages:
+
+     - **Message 1:** "Issues identified in the documents/files for the application: Prompt to follow and implement the fixes:
+     docs/calculator_consolidation_agent_prompt.md / Calculator consolidation analysis: docs/calculator_consolidation_analysis.md / I have implemented some
+     of these already, specially the items described below. Can you look through these and start implementing and completing the rest of the fixes. A summary
+     and narrative of the fixes and what was done is below: [10 bullet points describing completed work including stochastic audit, engine bridge,
+     advanced-v2 migration, parity testing, classic migration, reverse migration, manual mode, investment balance solver, scenario builder, confidence
+     separation]"
+
+     - **Message 2:** "Pause and reverify all the work completed. I believe there may be a glitch or you have missed some information. Please go through and
+     review your previous updates and implementations for: mistakes, missing steps, unsupported assumptions and invented details. Then rewrite the updates
+     and implementations more carefully and give a confidence rating from 1-10 for each. Then separately commit the various fixes done, and create a PR for
+     the branch to merge to master"
+
+     - **Message 3:** "review the PR"
+
+     7. Pending Tasks:
+
+     - **Complete PR #100 code review**: The `/code-review 100` skill was invoked and is executing. It fetched the PR diff (2773 lines, 6 commits ahead of
+     master covering the full consolidation) and was running multi-angle analysis. The review was interrupted by the summary request before producing
+     findings.
+
+     8. Current Work:
+
+     Immediately before this summary request, the code review of PR #100 was in progress. The `/code-review` skill had been invoked for PR #100 and was in
+     Phase 0 (gathering the diff via `gh pr diff 100`) when interrupted. The diff is 2773 lines covering:
+     - `src/advanced-v2.html` — new current household cashflow section
+     - `src/js/` — multiple calculation modules, adapters, reverse planner/solver/UI
+     - `src/js/calculation/reverse-scenario-engine.js` — new file
+     - `tests/unit/` — new and modified test files
+     - `src/reverse.html` — scenario builder section
+
+     The review was set up with high-effort parameters: "3+5 angles × 6 candidates → 1-vote verify (recall-biased) → ≤10 findings".
+
+     9. Optional Next Step:
+
+     The user asked "review the PR" and the `/code-review` skill was invoked. The review process started but was interrupted by this summary request. The
+     next step is to **complete the PR #100 code review** — running the multi-angle finder analysis (angles A through Conventions) across the full 2773-line
+     diff and producing the verified findings JSON array.
+
+     Direct quote from the most recent exchange:
+     - User: "review the PR"
+     - System launched `/code-review` with args `100`
+     - Review was in progress: `gh pr diff 100 2>&1 > /tmp/pr100.diff` completed (2773 lines), `git log master..HEAD --oneline` showed 6 commits, and the
+     8-angle finder process was about to begin
+
+     If you need specific details from before compaction (like exact code snippets, error messages, or content you generated), read the full transcript at:
+     /home/gagneet/.claude/projects/-home-gagneet-finance-retirement-calculator-au/379bee96-8d82-48a5-aafd-eeae15b8a3c3.jsonl
+     Continue the conversation from where it left off without asking the user any further questions. Resume directly — do not acknowledge the summary, do not
+     recap what was happening, do not preface with "I'll continue" or similar. Pick up the last task as if the break never happened.
+
+                                                                                                                           09:57 AM claude-sonnet-4-6
+● The PR covers the entire branch. Let me run the finder angles in parallel:
+
+● Agent(Correctness angle A — line-by-line diff scan)
+  ⎿  Prompt:
+       You are performing a code review on a retirement calculator codebase. Read the diff at /tmp/pr100.diff (use Bash: cat /tmp/pr100.diff). Then read
+       any touched functions in the actual source files to understand context.
+
+       Find up to 6 candidates with concrete failure scenarios. Focus on: inverted/wrong conditions, null/undefined deref, missing await, falsy-zero
+       checks, wrong-variable copy-paste, error swallowed in catch, unescaped regex, off-by-one.
+
+       For each candidate return: file, line number (from the diff or source), one-line summary, concrete failure scenario (inputs → wrong
+       output/crash).
+
+       Key files to check after reading the diff:
+       - src/js/calculation/reverse-scenario-engine.js
+       - src/js/reverse-ui.js
+       - src/js/reverse-solver.js
+       - src/js/reverse-planner.js
+       - src/js/advanced-v2.js (projection service wiring)
+       - src/js/calculation/projection-service.js
+       - src/js/calculation/household-cashflow-engine.js
+
+       Return JSON array of candidates.
+  ⎿  Response:
+       Here are the 6 candidates with concrete failure scenarios:
+
+       [
+         {
+           "file": "src/js/calculation/household-cashflow-engine.js",
+           "line": 56,
+           "summary": "mortgage_first allocation cap mixes annual-flow units with a total-balance dollar amount",
+           "scenario": "User has $300 k/yr surplus and a $50 k mortgage remaining. allocations.mortgage = Math.min(300000, 50000) = 50 000 (annual
+       dollars). The canonical-engine-adapter then adds allocations.mortgage / 12 ≈ $4 167/mo as extra mortgage repayment. After ~12 months the full
+       balance is repaid, but the engine keeps adding the overpayment to monthlyMortgagePayment for the rest of the accumulation phase, inflating
+       savings by thousands of dollars and understating liquid investments."
+         },
+         {
+           "file": "src/js/calculation/canonical-engine-adapter.js",
+           "line": 15,
+           "summary": "When totalSpendProvided is true (advanced-v2 'detailed cashflow' mode), currentMonthlyHousingCosts is written as 0 because the v2
+       adapter never populates that field — all spending lands in currentMonthlyLivingCosts",
+           "scenario": "User on advanced-v2 enables 'Model income minus current spending', enters $7 000/mo total spend. The canonical adapter receives
+       currentMonthlyTotalSpend = 7 000 and currentMonthlyHousingCosts = 0. canonical-engine-adapter (line 15) writes
+       engineInputs.currentMonthlyHousingCosts = 0. simulator.extractBaseExpensesFromCashFlow (simulator.js line 3773) then returns housingExpense = 0,
+       livingExpense = 7 000. buildRetirementSpendingPlan computes retirementHousing = 0 and derives a lower essentialBase than intended, causing
+       retirement withdrawal to be systematically underestimated for every year of the retirement phase."
+         },
+         {
+           "file": "src/js/calculation/reverse-scenario-engine.js",
+           "line": 123,
+           "summary": "noCurrentAssets scenario block zeroes balances but not annualCashSavingsContribution, so the 'salary and savings path from zero'
+       scenario still receives the derived cashflow surplus as a free annual injection",
+           "scenario": "User has detailed cashflow enabled with $156 k/yr surplus allocated to cash. canonical-engine-adapter set
+       engineInputs.annualCashSavingsContribution = 156 000 before the scenario engine runs. applyScenario for key='salary_only' zeroes
+       yourCurrentSuper, currentSavings, currentStocks, investmentPropertyValue — but not annualCashSavingsContribution. simulator.js line 1891 takes
+       the Number.isFinite branch and accumulates $156 000/yr from day one. The scenario result shows far higher required salary than it should, because
+       the projection is secretly receiving $156 k/yr regardless."
+         },
+         {
+           "file": "src/js/advanced-v2.js",
+           "line": 1690,
+           "summary": "Dead ?? fallback in normalizeImportedUserData: the arithmetic sub-expression always produces a number, so
+       base.currentMonthlyLivingCosts is never reached",
+           "scenario": "Old userData imported from a pre-PR forward projection that used only top-level expenses (no currentMonthlyTotalSpend, all
+       component fields absent). The expression evaluates (undefined ?? 0) + (undefined ?? 0) + (undefined ?? 0) / 12 = 0, which is a number, so `??
+       base.currentMonthlyLivingCosts` is never consulted. Result: currentMonthlyLivingCosts is silently set to 0 instead of the UI default, and the
+       next calculation (if detailed cashflow is on) derives a $0 spending base, inflating the computed surplus and overstating accumulation."
+         },
+         {
+           "file": "src/js/reverse-ui.js",
+           "line": 481,
+           "summary": "el('rsb-include-pension')?.checked !== false always returns true when the DOM element is absent, treating the missing checkbox as
+       'pension included' regardless of user intent",
+           "scenario": "handleScenarioBuilder() is called programmatically (e.g. from a test harness or before the rsb-section has been rendered into
+       the DOM). el('rsb-include-pension') returns null, so ?.checked is undefined. undefined !== false evaluates to true. Both target.includeAgePension
+       and selected.includeAgePension are forced to true, overriding any intent to model a private-savings-only scenario. solveScenario passes
+       suppressAgePension: false, and all scenarios including 'home_super_private' (which explicitly sets includeAgePension: false in
+       buildScenarioDefinitions) receive pension income in their baseline projection, inflating estimated assets at retirement."
+         },
+         {
+           "file": "src/js/reverse-planner.js",
+           "line": 336,
+           "summary": "When hasCompleteProjection is true, solverBaseInputs = { ...projection.engineInputs } unconditionally, but the loaded forward
+       projection may have been computed with a different targetAnnualIncomeToday, making the bisection solver search for the wrong goal",
+           "scenario": "User saves a forward projection targeting $60 000/yr income. Later opens Reverse Planner with a new target of $90 000/yr.
+       loadedProjection passes hasCompleteProjection=true (it has inputHash, canonicalInput, engineInputs, simulation). projectionInput overrides
+       asfaComfortable and targetAnnualIncomeToday to $90 000 (lines 279-282) but the projection is the stale loaded one — projection.engineInputs still
+       has asfaComfortable = 60 000. solverBaseInputs = { ...projection.engineInputs } inherits asfaComfortable = 60 000. applyTargetToEngineInputs on
+       line 338 is supposed to correct this, but if the field name written there differs from the one the success predicate reads (asfaComfortable vs
+       targetAnnualIncomeToday), the solver bisects against the old $60 k target and reports required values that are far too low."
+         }
+       ]
+
+       Summary of findings:
+
+       1. household-cashflow-engine.js:56 — unit mismatch in mortgage_first cap. availableSurplus is an annual dollar amount;
+       currentAssets.mortgageBalance is the total outstanding balance. When annual surplus exceeds the remaining balance, the engine allocates more than
+       the whole debt as an annual extra payment, causing perpetual overpayment after the mortgage is cleared.
+       2. canonical-engine-adapter.js:15 — housing always zero in totalSpendProvided mode. The advanced-v2 adapter maps everything to
+       currentMonthlyTotalSpend but never populates currentMonthlyHousingCosts. The adapter writes it as 0, so buildRetirementSpendingPlan computes a
+       zero housing line and underestimates essential retirement spending.
+       3. reverse-scenario-engine.js:123 — noCurrentAssets block misses annualCashSavingsContribution. The salary_only scenario zeroes all asset
+       balances and stock contributions but not the derived surplus contribution injected by the canonical cashflow adapter. The "start from zero"
+       scenario silently receives the full derived surplus, inflating required-salary solver results.
+       4. advanced-v2.js:1690 — dead ?? fallback. The arithmetic sub-expression (A??0)+(B??0)+(C??0)/12 always evaluates to a number (never
+       null/undefined), so ?? base.currentMonthlyLivingCosts is unreachable. Importing legacy user data with no spending fields silently yields 0
+       instead of the UI default.
+       5. reverse-ui.js:481 — el()?.checked !== false misreads absent checkboxes as checked. If the DOM element is null, undefined !== false is true,
+       forcing includeAgePension = true even when the user never saw or set the checkbox.
+       6. reverse-planner.js:336 — stale asfaComfortable in solver base inputs when loaded projection target differs. When a complete forward projection
+       is loaded, solverBaseInputs inherits the projection's original asfaComfortable target. If the user opens Reverse Planner with a different income
+       target, the bisection solvers search against the old goal.
+  ⎿  Done (79 tool uses · 110.6k tokens · 8m 41s)
+
+● Agent(Correctness angle B — removed-behavior auditor)
+  ⎿  Prompt:
+       You are performing a code review on a retirement calculator codebase. Read the diff at /tmp/pr100.diff (use Bash: cat /tmp/pr100.diff).
+
+       Your job: for every line the diff DELETES or replaces, name the invariant or behavior it enforced, then search the NEW code for where that
+       invariant is re-established. If you can't find it, surface it as a candidate.
+
+       Focus on:
+       - Guards that were removed
+       - Error paths that were dropped
+       - Validations narrowed
+       - Tests deleted that covered real cases
+       - Fallback logic removed
+
+       Key areas to check:
+       - Were there any pre-existing checks in reverse-planner.js, reverse-solver.js that got removed?
+       - Does the new projection-service path drop any field that was previously passed through?
+       - Does normaliseInputs being called on already-normalised inputs cause double-conversion of rates?
+
+       Return JSON array of up to 6 candidates: {file, line, summary, failure_scenario}
+  ⎿  Response:
+       Now I have a complete picture. Let me compile the final analysis:
+
+       [
+         {
+           "file": "src/js/calculation/projection-service.js",
+           "line": 64,
+           "summary": "normaliseInputs() called on output of engineInputBuilder, which for the reverse-planner path may already contain decimal-form
+       rates (normalised by normaliseReversePlannerInputs). Calling normaliseInputs again on a field like mortgageRate=0.06 is idempotent (|0.06|≤1
+       passes through), but for a legacy export where mortgageRate arrived as 6.0 and was already converted to 0.06 by normaliseReversePlannerInputs,
+       passing through normaliseInputs is fine. However, the engineInputBuilder in reverse-planner.js conditionally skips normaliseReversePlannerInputs
+       when rawInput.yourCurrentAge is already finite — in that branch it spreads the raw engineInputs from the forward-projection localStorage. Those
+       engineInputs were normalised once by the originating calculator. The second normaliseInputs call is idempotent for values ≤1, but if the stored
+       engineInputs had any rate field > 1 (e.g. a RATE_FIELD that was not caught by the first normaliser), it will be divided by 100 again, silently
+       halving a rate.",
+           "failure_scenario": "User imports a forward projection saved before PR#100 where a rate field (e.g. leanYearsReduction=0.3) was stored at its
+       display value. The reverse-planner engineInputBuilder spreads those stored engineInputs verbatim, then projection-service.js calls
+       normaliseInputs on them. leanYearsReduction=0.3 satisfies |v|≤1 so it passes through — but any field that was accidentally stored as a percentage
+       (>1) gets divided again, corrupting the projection silently."
+         },
+         {
+           "file": "src/js/reverse-planner.js",
+           "line": 288,
+           "summary": "Removed hasEngineInputs guard replaced with unconditional `projection.engineInputs` spread. The old code checked that
+       projection.engineInputs was a non-empty object with a recognisable age field before trusting it as the solver base. The new code unconditionally
+       uses `projection.engineInputs` as solverBaseInputs with no fallback. If ProjectionService.computeProjection throws or if the engineInputBuilder
+       returns an object without yourCurrentAge (e.g. when forward-projection localStorage has malformed engineInputs), `solverBaseInputs` will contain
+       a structurally incomplete object and all solver calls will silently compute with age=undefined, producing NaN-filled results.",
+           "failure_scenario": "If `loadedProjection.engineInputs` exists but is missing `yourCurrentAge` (e.g. stored from a pipeline that uses `age`
+       instead), the removed guard would have fallen back to `baseInputs`. Now solverBaseInputs gets `yourCurrentAge=undefined`, causing the solver to
+       compute yearsToRetirement as NaN, which propagates through bisection to produce Infinity or NaN targets for all levers."
+         },
+         {
+           "file": "src/js/calculation/canonical-input-schema.js",
+           "line": 18,
+           "summary": "totalSpendProvided is derived purely from whether the key 'currentMonthlyTotalSpend' exists in cashflow, not from whether it is
+       non-zero. The advanced-v2-adapter always passes cashflow.currentMonthlyTotalSpend=input.currentMonthlyLivingCosts even when useDetailedCashflow
+       is false and currentMonthlyLivingCosts=0. This means totalSpendProvided becomes true even for users with the feature disabled, so
+       household-cashflow-engine.js uses currentMonthlyTotalSpend=0 as the spending figure when hasDetailedExpenses=false — causing
+       currentAnnualSpending=0 and canAllocateSurplus=false. The interaction with hasDetailedExpenses gating canAllocateSurplus saves it from
+       double-counting, but the schema state (totalSpendProvided=true, hasDetailedExpenses=false) is inconsistent and could affect future consumers of
+       canonicalInput.",
+           "failure_scenario": "Any code that reads canonicalInput.cashflow.totalSpendProvided to decide spending basis (e.g. a future reporting layer)
+       will see true even when the user never enabled detailed cashflow. This could cause incorrect UI labels or comparison logic to show 'total spend
+       basis' when the user set explicit contributions only."
+         },
+         {
+           "file": "src/js/reverse-planner.js",
+           "line": 1405,
+           "summary": "Deleted line `g.normalizedValue = totalAchieved > 0 ? g.achievedValue / totalAchieved : 0` removed from buildCurrentPath. This
+       line no longer exists anywhere in the codebase — neither in the pre-PR nor post-PR versions (it appears to have referenced variables `g` and
+       `totalAchieved` that are not declared elsewhere in buildCurrentPath). The deletion is correct in isolation but signals the line may have been a
+       leftover from an old gap-loop that was partially cleaned up in an earlier PR, leaving dead code that this PR removes. No invariant is lost, but
+       confirms the old gap analysis loop was silently writing to a `g` object that is no longer returned or tested.",
+           "failure_scenario": "Non-issue for runtime, but indicates a test gap: no test in the existing suite asserted on
+       `currentPath.gaps[*].normalizedValue`, so any consumer that was expecting a normalized weight breakdown of gap components will silently receive
+       `undefined`."
+         },
+         {
+           "file": "tests/integration/reverse-integration.test.js and tests/unit/reverse-solver-roundtrip.test.js",
+           "line": 1957,
+           "summary": "Both files removed the `beforeAll` that pinned `Math.random` to 0.5. The stated justification is that deterministic mode is now
+       truly deterministic (Box-Muller with mocked random=0.5 was the old workaround). However, ProjectionService calls simulateRetirement with
+       stochastic=false, so the simulator's stochasticRate should return the central value unchanged. But stochasticRate is called with isStochastic
+       from `effectiveInputs.useStochasticReturns`, not from the second argument in all call sites — if any call site inside simulateRetirement passes
+       `useRandomReturns=true` regardless of the deterministic flag, removing the Math.random pin will make those tests non-deterministic and bisection
+       tolerances may occasionally fail.",
+           "failure_scenario": "If any per-year stochasticRate call inside simulator.js uses `useRandomReturns` that evaluates to true in a test run
+       (e.g. because a test fixture passes `useStochasticReturns: true` or a default evaluates truthy), the bisection solver round-trip tests will now
+       produce different solved values across runs, causing sporadic CI failures that are hard to reproduce locally."
+         },
+         {
+           "file": "src/js/calculation/canonical-engine-adapter.js",
+           "line": 26,
+           "summary": "When canAllocateSurplus is true and surplusAllocationMode='super_first', the adapter sets yourAdditionalSuperContribution +=
+       derivedCashflow.superByMember.primary but does NOT update employerSuperContributionRate or flag that the additional super is post-tax vs pre-tax.
+       The household-cashflow-engine warning notes this ('Super-first amounts require the projection adapter to model contribution tax'). The old code
+       path had no surplus allocation at all, so no incorrect super contribution was ever injected. Now the engine receives inflated
+       yourAdditionalSuperContribution without the corresponding concessional-cap check that app.js normally performs in validateInputs, so a user with
+       a large surplus could silently exceed the $30,000 concessional cap and the simulator will not cap it.",
+           "failure_scenario": "A couple with $20k/month income and $5k/month spending in 'super_first' mode: surplus=$15k/month=$180k/year. After
+       employer SG, primaryCapRoom is only $18k. The engine correctly caps to $18k. But the adapter adds $18k to the existing
+       yourAdditionalSuperContribution without checking whether the user already entered an explicit salary sacrifice that consumed part of that cap —
+       resulting in total concessional contributions exceeding $30,000 with no warning and no cap enforcement in the simulation."
+         }
+       ]
+
+       Here is the JSON array of candidates:
+
+       [
+         {
+           "file": "src/js/calculation/projection-service.js",
+           "line": 64,
+           "summary": "normaliseInputs() called on engineInputBuilder output which, in the reverse-planner path, may already have decimal rates from a
+       prior normalisation pass. The engineInputBuilder conditionally skips normaliseReversePlannerInputs when rawInput.yourCurrentAge is already
+       finite, spreading stored localStorage engineInputs directly. If any RATE_FIELD value in those stored inputs is > 1 (e.g. from an older export),
+       the second normaliseInputs call will halve it silently.",
+           "failure_scenario": "User opens the reverse planner after importing a pre-PR100 forward projection where a rate field was stored as a
+       percentage (>1). The stored engineInputs are spread verbatim by the engineInputBuilder, then normaliseInputs divides the field again, corrupting
+       the projection with no error or warning."
+         },
+         {
+           "file": "src/js/reverse-planner.js",
+           "line": 336,
+           "summary": "Removed hasEngineInputs guard (which checked projection.engineInputs was non-empty and had a valid age field) is not replaced.
+       The new code unconditionally uses projection.engineInputs as solverBaseInputs. If engineInputBuilder returns an object without yourCurrentAge
+       (possible when the forward-projection localStorage payload comes from a calculator that stores the field as 'age' instead), all solver calls
+       receive yourCurrentAge=undefined, producing NaN yearsToRetirement through every bisection lever.",
+           "failure_scenario": "A projection stored by the classic advanced.html page uses 'age' not 'yourCurrentAge' as the primary age key. The old
+       guard fell back to baseInputs in this case; the new code blindly spreads the incomplete engineInputs, and every lever solve returns Infinity or
+       NaN."
+         },
+         {
+           "file": "src/js/calculation/canonical-input-schema.js",
+           "line": 18,
+           "summary": "totalSpendProvided is derived from key presence ('currentMonthlyTotalSpend' in cashflow), not from whether the value is non-zero
+       or whether the user opted in. The advanced-v2-adapter always passes currentMonthlyTotalSpend=input.currentMonthlyLivingCosts even when
+       useDetailedCashflow=false and the field value is 0. So totalSpendProvided becomes true regardless of the toggle, leaving canonicalInput in an
+       inconsistent state (totalSpendProvided=true, hasDetailedExpenses=false) that any future consumer reading totalSpendProvided alone would
+       misinterpret.",
+           "failure_scenario": "A reporting layer or future canonical consumer reads canonicalInput.cashflow.totalSpendProvided=true and assumes a
+       total-spend basis was entered, and switches to totalSpend-based expense display, even though the user left all cashflow fields at zero and never
+       enabled detailed cashflow."
+         },
+         {
+           "file": "tests/integration/reverse-integration.test.js and tests/unit/reverse-solver-roundtrip.test.js",
+           "line": 1957,
+           "summary": "Both test files removed the beforeAll that pinned Math.random to 0.5. The stated reason is that deterministic mode is now truly
+       deterministic. However the flag controlling stochastic mode inside simulator.js is effectiveInputs.useStochasticReturns, not the second argument
+       to simulateRetirement alone. If a test fixture inadvertently carries useStochasticReturns: true (or undefined where the default is truthy),
+       removing the random pin will make bisection results vary across runs.",
+           "failure_scenario": "A test fixture in either suite passes useStochasticReturns without explicitly setting it to false. The simulator draws
+       random normal values, bisection converges to a slightly different fixed point each run, and a tolerance-bounded assertion like toBeCloseTo(x, 0)
+       fails intermittently in CI."
+         },
+         {
+           "file": "src/js/calculation/canonical-engine-adapter.js",
+           "line": 34,
+           "summary": "In super_first surplus allocation mode, the adapter increments yourAdditionalSuperContribution by
+       derivedCashflow.superByMember.primary without checking whether existing explicit salary sacrifice (also stored in yourAdditionalSuperContribution
+       after normalisation) has already consumed part or all of the concessional cap. The household-cashflow-engine computes capRoom against
+       income.employerSuperAnnual and cashflow.explicitAnnualSalarySacrifice, but the adapter then adds the surplus super on top of the existing
+       yourAdditionalSuperContribution without re-capping.",
+           "failure_scenario": "A user with $18,000 salary sacrifice already entered and employer SG of $12,000 has zero remaining concessional cap.
+       household-cashflow-engine correctly computes primaryCapRoom=0 so superByMember.primary=0. But if the user's explicit salary sacrifice was passed
+       as salarySacrifice (raw) and normalised into yourAdditionalSuperContribution at a different point in the chain, the adapter may add a second copy
+       of the sacrifice, silently doubling super contributions past the cap with no capping or warning in the simulation."
+         },
+         {
+           "file": "src/js/reverse-planner.js",
+           "line": 278,
+           "summary": "When hasCompleteProjection is false (no valid localStorage projection), projectionInput is constructed from
+       loadedProjection.engineInputs if they exist, even when hasCompleteProjection failed because canonicalInput.schemaVersion was absent. This means
+       an old-format payload where engineInputs are present but canonicalInput is null will use those engineInputs as the raw input to
+       projectionService.computeProjection, bypassing normaliseReversePlannerInputs entirely. The old code path in this branch was
+       `buildCurrentPath(baseInputs, resolvedTarget)` which used fully normalised baseInputs.",
+           "failure_scenario": "A v1 forward projection payload has engineInputs but no canonicalInput.schemaVersion. hasCompleteProjection=false, so
+       the else branch runs computeProjection with loadedProjection.engineInputs. These inputs are already normalised engine-format objects, so
+       adaptReverseManualInput maps them through canonical-input-schema (which applies normaliseRate to assumptions.*), then normaliseInputs is called
+       again — double-normalising any rate field that arrives as a decimal in a RATE_FIELDS set that treats |v|>1 as a percentage. For values already ≤1
+       this is idempotent, but the path is fragile and not tested."
+         }
+       ]
+  ⎿  Done (41 tool uses · 96.7k tokens · 3m 39s)
+
+● Agent(Correctness angle C — cross-file call-site tracer)
+  ⎿  Prompt:
+       You are performing a code review on a retirement calculator codebase. Read the diff at /tmp/pr100.diff (use Bash: cat /tmp/pr100.diff).
+
+       Your job: for each function the diff changes or adds, find its callers and check whether the change breaks any call site. Also check callees —
+       does a parallel change make a call unsafe?
+
+       Specific things to trace:
+       1. solveAllLevers now returns investmentBalResult in its output. Check all callers of solveAllLevers in the codebase (grep for it) and verify
+       they handle the new lever correctly.
+       2. normaliseReversePlannerInputs now returns partnerCurrentAge, partnerRetirementAge, partnerLifespan. Find callers. Do any callers break or
+       ignore these new fields?
+       3. ReverseScenarioEngine.applyScenario — are this.config.COUPLE_ASSET_THRESHOLD, COUPLE_ASSET_LIMIT, SINGLE_ASSET_THRESHOLD, SINGLE_ASSET_LIMIT
+       etc. all guaranteed to be present in the config passed to the constructor? (Check what config the ReverseUI passes)
+       4. handleScenarioBuilder in reverse-ui.js calls this.planner.projectionService.computeProjection(projectionInput, ...) where projectionInput may
+       contain engine-level fields mixed with raw UI fields. Does the projection service adapter handle this correctly?
+       5. The compareScenarios call passes projection.engineInputs — these come from normaliseInputs(). Does applyScenario then call normaliseInputs
+       again (double-normalisation)?
+
+       Use Bash to grep for callers. Read the relevant source files. Return JSON array of up to 6 candidates: {file, line, summary, failure_scenario}
+  ⎿  Response:
+       I now have everything I need to produce the review. Here is the JSON array of findings:
+
+       [
+         {
+           "file": "src/js/reverse-planner.js",
+           "line": 340,
+           "summary": "solveAllLevers caller destructures only { rankedLevers } — investmentBalResult is inside rankedLevers and is handled, but the
+       return value comment only shows currentScore, currentResult, rankedLevers. This caller is fine; investmentBalResult is inside rankedLevers after
+       rankLevers() is called in the solver, so it is automatically included in the ranked output and picked up by reverse-ui.js's switch-case for
+       'investmentBalance'. No breakage here.",
+           "failure_scenario": "No failure. The new lever enters rankedLevers via allLevers[], and both reverse-planner.js and reverse-ui.js already
+       have 'investmentBalance' case handling in their switch statements (lines 961, 979, 1469, 1490 of reverse-ui.js). However, the new lever was not
+       previously in rankedLevers, so any call sites that assumed a specific index in rankedLevers[] rather than using .find() would silently shift. All
+       existing callers use .find(), so this is safe."
+         },
+         {
+           "file": "src/js/reverse-ui.js",
+           "line": 455,
+           "summary": "handleScenarioBuilder passes projectionInput (containing raw UI fields like currentAge, yourCurrentAge, partnerAge,
+       partnerCurrentAge, etc.) directly to this.planner.projectionService.computeProjection(). The ReversePlanner's engineInputBuilder has a guard: 'if
+       Number.isFinite(rawInput.yourCurrentAge) → use rawInput as-is, else call normaliseReversePlannerInputs(rawInput)'. Since projectionInput sets
+       yourCurrentAge: currentAge (a number), the guard passes through the raw object unchanged. The raw object also carries keys from baseEngineInputs
+       (possibly from a prior engine run) mixed with the RSB form fields. The adaptReverseManualInput adapter reads input.currentAge ??
+       input.yourCurrentAge for household.currentAge, so it correctly finds yourCurrentAge. However the raw object may also carry engine-level fields
+       (e.g., _normalisedAt, canonicalInputSchemaVersion) from a prior engineInputs spread, which get hashed but do not break anything.",
+           "failure_scenario": "No hard crash, but if baseEngineInputs comes from this.forwardProjection?.engineInputs (which already went through
+       normaliseInputs and has _normalisedAt etc.), those stale metadata keys participate in the input hash, causing spurious cache misses on the second
+       run when the scenario-builder re-runs with the same UI inputs but the prior engineInputs reference differs. Not a data correctness bug, but a
+       performance/cache coherence issue."
+         },
+         {
+           "file": "src/js/calculation/reverse-scenario-engine.js",
+           "line": 143,
+           "summary": "applyScenario reads this.config.COUPLE_ASSET_THRESHOLD, COUPLE_ASSET_LIMIT, SINGLE_ASSET_THRESHOLD, SINGLE_ASSET_LIMIT,
+       COUPLE_ASSET_THRESHOLD_NON_HOMEOWNER, COUPLE_ASSET_LIMIT_NON_HOMEOWNER, SINGLE_ASSET_THRESHOLD_NON_HOMEOWNER, SINGLE_ASSET_LIMIT_NON_HOMEOWNER.
+       ReverseUI passes ENHANCED_CONFIG to new ReverseScenarioEngine(ENHANCED_CONFIG). ENHANCED_CONFIG (config.js lines 37-44) defines all eight
+       constants. No missing keys.",
+           "failure_scenario": "Safe. All eight pension-threshold constants are present in ENHANCED_CONFIG. A risk would arise only if
+       ReverseScenarioEngine were constructed with a different config object (e.g., a test stub). Tests in reverse-scenario-engine.test.js pass
+       ENHANCED_CONFIG, which contains all constants."
+         },
+         {
+           "file": "src/js/reverse-planner.js",
+           "line": 67,
+           "summary": "normaliseReversePlannerInputs now returns partnerCurrentAge, partnerRetirementAge, partnerLifespan. The only callers in src are:
+       (1) the engineInputBuilder inside ReversePlanner.projectionService (line 138) — the returned object is passed as baseEngineInputs to
+       applyCanonicalCashflowToEngineInputs and then to normaliseInputs in projection-service.js; (2) ReversePlanner.solve() (line 244) — result is used
+       only as baseInputs for householdMeta building and the return value's inputs field. The simulator already reads partnerCurrentAge,
+       partnerRetirementAge, partnerLifespan from inputs (simulator.js lines 1039, 1065, 1270-1272), so the new fields are additive and safe. Tests in
+       reverse-planner-regression.test.js cover the single-household path where they are 0.",
+           "failure_scenario": "No failure for the callers in src. However, any external caller that pattern-matches or spreads the return value
+       expecting the old three-field shape (yourCurrentAge, retirementAge, yourLifespan) and doesn't tolerate extra keys could get confused — but no
+       such caller exists in src. The new fields are ignored by callers that don't use them."
+         },
+         {
+           "file": "src/js/reverse-planner.js",
+           "line": 288,
+           "summary": "When loadedProjection has engineInputs but is NOT treated as hasCompleteProjection (e.g., lacks inputHash or
+       canonicalInput.schemaVersion), projectionInput is built as { ...loadedProjection.engineInputs, ... } and passed to
+       projectionService.computeProjection(). The engineInputBuilder checks Number.isFinite(rawInput.yourCurrentAge). If loadedProjection.engineInputs
+       uses the old field name yourCurrentAge (from the classic calculator), this passes. If however it uses a different key like 'age' (from
+       advanced-v2), yourCurrentAge is undefined, and normaliseReversePlannerInputs is called on the engine-level object which lacks the expected
+       rawInput fields (currentAge, partnerAge, etc.). normaliseReversePlannerInputs then falls back to defaults (age 50, retirement 67) rather than the
+       loaded values.",
+           "failure_scenario": "Regression: if a forward projection was stored by advanced-v2 (where engineInputs uses keys like 'age' not
+       'yourCurrentAge') and the payload lacks inputHash, the reverse planner falls back to normaliseReversePlannerInputs on the engine inputs, reads
+       default age 50 instead of the user's actual age, and produces a wrong solver baseline. The hasCompleteProjection guard was tightened in this diff
+       to also require canonicalInput.schemaVersion, which means old payloads that have engineInputs and simulation but no inputHash/schemaVersion now
+       fall through to projectionService.computeProjection with potentially mis-keyed engine inputs."
+         },
+         {
+           "file": "src/js/calculation/projection-service.js",
+           "line": 64,
+           "summary": "ProjectionService.computeProjection() calls normaliseInputs() on the output of engineInputBuilder (line 64), and compareScenarios
+       in ReverseScenarioEngine calls this.planner.projectionService.computeProjection(projectionInput) then passes projection.engineInputs directly to
+       solveScenario → applyScenario → solver.solveAllLevers. The solver does NOT call normaliseInputs internally. So engineInputs has already been
+       through normaliseInputs once (in projection-service). applyScenario then mutates a shallow copy and passes it to applyTargetToEngineInputs which
+       also does not re-normalise. This is correct — no double-normalisation. The concern in question 5 is a false alarm: compareScenarios receives
+       projection.engineInputs (already normalised) and applyScenario does not call normaliseInputs again.",
+           "failure_scenario": "No double-normalisation bug. However, there is a subtle issue: applyScenario reads inputs.investmentReturn and
+       inputs.superReturn (lines 1179-1181) but these fields come from the engine inputs produced by the reverse-manual adapter. If the user did not
+       provide those fields in the RSB form and baseEngineInputs was empty (this.forwardProjection and this.lastResult?.projection?.engineInputs are
+       both null on first load), investmentReturn and superReturn will be undefined, and the stress scenario applies 'Math.max(0, undefined - 0.02)' =
+       0. This silently zeroes the return rates for the stress scenario rather than using sensible defaults."
+         }
+       ]
+
+       Here is a summary of the findings:
+
+       ---
+       Finding 1 — solveAllLevers / investmentBalResult (safe)
+       investmentBalResult is added to allLevers[] and flows into rankedLevers via rankLevers(). Both call sites in reverse-planner.js and reverse-ui.js
+       consume rankedLevers generically using .find() / .filter(), and reverse-ui.js already has a case 'investmentBalance': in both its
+       leverCurrentValue and leverRequiredValue switch blocks (lines 961, 979, 1469, 1490). No breakage.
+
+       Finding 2 — normaliseReversePlannerInputs new partner fields (safe)
+       The three new fields (partnerCurrentAge, partnerRetirementAge, partnerLifespan) are returned alongside the original fields. All callers in src/
+       either spread the result into objects the simulator already reads (which consumes those fields correctly via simulator.js lines 1039, 1065,
+       1270-1272) or use named destructuring that simply ignores the extra fields. Additive and safe.
+
+       Finding 3 — ReverseScenarioEngine config keys (safe)
+       All eight pension-threshold constants (COUPLE_ASSET_THRESHOLD, COUPLE_ASSET_LIMIT, SINGLE_ASSET_THRESHOLD, SINGLE_ASSET_LIMIT, and the four
+       _NON_HOMEOWNER variants) are defined in ENHANCED_CONFIG at config.js lines 37-44. ReverseUI passes ENHANCED_CONFIG to new
+       ReverseScenarioEngine(ENHANCED_CONFIG). No missing keys.
+
+       Finding 4 — handleScenarioBuilder projectionInput with mixed fields (minor cache issue)
+       The projectionInput built in collectScenarioBuilderInputs() spreads baseEngineInputs (which may already be a normalised engine-inputs object with
+       _normalisedAt, canonicalInputSchemaVersion, etc.) together with fresh UI fields. These metadata keys from a prior engine run participate in the
+       FNV-1a hash, causing spurious cache misses on repeat runs with identical user inputs. Not a data correctness bug but a cache coherence defect.
+
+       Finding 5 — Potential regression on old forward projections without inputHash/schemaVersion (real bug)
+       hasCompleteProjection now requires loadedProjection.inputHash && loadedProjection.canonicalInput?.schemaVersion. Old payloads stored before this
+       PR (which have engineInputs and simulation but no inputHash) no longer qualify. They fall into the
+       projectionService.computeProjection(projectionInput) branch where projectionInput = { ...loadedProjection.engineInputs, ... }. If those engine
+       inputs use advanced-v2 key names (age not yourCurrentAge), the engineInputBuilder's guard Number.isFinite(rawInput.yourCurrentAge) evaluates
+       undefined → false, so normaliseReversePlannerInputs() is called on the already-engine-level object and defaults age to 50 rather than the user's
+       real age. File: /home/gagneet/finance/retirement_calculator_au/src/js/reverse-planner.js, line 278–291.
+
+       Finding 6 — Stress scenario silently zeroes returns when RSB has no prior projection (real bug)
+       In applyScenario (lines 1179-1181 of reverse-scenario-engine.js), the stress branch does:
+       inputs.investmentReturn = Math.max(0, (inputs.investmentReturn || 0.07) - 0.02);
+       inputs.superReturn = Math.max(0, (inputs.superReturn || 0.075) - 0.02);
+       These fields are read from the engine inputs output by projectionService. When baseEngineInputs in collectScenarioBuilderInputs() comes from an
+       empty object (no forward projection loaded, no prior result), the engine inputs go through normaliseInputs() which fills defaults, so
+       investmentReturn and superReturn will actually be populated from DEFAULT_RATES. This is fine normally — but the || 0.07 / || 0.075 fallbacks in
+       applyScenario are different from the normaliseInputs defaults, creating a subtle inconsistency if the normalised defaults ever differ. Not a hard
+       crash, but worth verifying the default values agree.
+  ⎿  Done (38 tool uses · 86.6k tokens · 2m 42s)
+
+● Agent(Angles: reuse + simplification + efficiency + altitude + conventions)
+  ⎿  Prompt:
+       You are performing a code review on a retirement calculator codebase. Read the diff at /tmp/pr100.diff (use Bash: cat /tmp/pr100.diff). Read
+       CLAUDE.md at /home/gagneet/finance/retirement_calculator_au/CLAUDE.md and any relevant source files.
+
+       Run 5 sub-angles and surface up to 6 total candidates:
+
+       Reuse: Does any new code re-implement something already in the codebase? Grep shared/utility modules. Name the existing helper.
+
+       Simplification: Redundant state, copy-paste with slight variation, deep nesting, dead code. Name the simpler form.
+
+       Efficiency: Redundant computation, sequential independent operations, memory leaks from closures. In particular: does
+       ReverseScenarioEngine.compareScenarios run scenarios sequentially in a for-loop when they could run in parallel? Does handleScenarioBuilder
+       create a new projection for each call when the inputs haven't changed?
+
+       Altitude: Is any fix a band-aid on shared infrastructure? Special-casing that should be generalized?
+
+       Conventions (CLAUDE.md): Read CLAUDE.md carefully. Check:
+       - "No emoji in PDF output" — do any strings added to PDF sections contain emoji?
+       - "stochasticRate" usage conventions
+       - Nominal vs real values — does any new code confuse them?
+       - Pipeline A/B/C separation — does new code correctly stay in its lane?
+       - Any comment styles that violate "default to writing no comments"?
+
+       Quote the exact rule and exact line for any conventions finding.
+
+       Return JSON array of up to 6 candidates: {file, line, summary, failure_scenario}
+  ⎿  Response:
+       Here is the review result:
+
+       [
+         {
+           "file": "src/js/calculation/reverse-scenario-engine.js",
+           "line": 186,
+           "summary": "Efficiency: compareScenarios runs 10 scenario solves sequentially in a for-await loop instead of using Promise.all. Each
+       solveScenario call awaits solver.solveAllLevers which itself uses Promise.all internally. The outer sequential loop leaves 9 of 10 lever-solve
+       batches waiting for the previous one to finish.",
+           "failure_scenario": "A single handleScenarioBuilder invocation takes approximately 10× longer than necessary for a user on a slow device.
+       Since each solveScenario call is independent (baseEngineInputs is immutable), all 10 can be dispatched together: `const results = await
+       Promise.all(definitions.map(def => this.solveScenario(baseEngineInputs, target, def, options)))`."
+         },
+         {
+           "file": "src/js/reverse-ui.js",
+           "line": 52,
+           "summary": "Reuse: escapeHtml is re-defined verbatim in reverse-ui.js (line 52) when an identical function already exists at
+       src/js/advanced-v2.js line 1458. The two implementations diverge on the single-quote encoding ('&#039;' vs '&#39;'). Neither is exported from a
+       shared module.",
+           "failure_scenario": "If the encoding logic is ever changed in one file the other silently stays stale. The fix is to export escapeHtml from
+       utils.js (where it logically belongs alongside formatCurrency and DOM helpers) and import it in both callers."
+         },
+         {
+           "file": "src/js/simulator.js",
+           "line": 82,
+           "summary": "Conventions (CLAUDE.md): stochasticSigmaForRate sets salary multiplier to 0.3, but CLAUDE.md §Stochastic Rate Model states
+       'Salary growth: σ = max(0.5%, |rate| × 40%)'. Pipeline B (life_simulation_engine.js line 206) correctly uses 0.4. The new shared function
+       diverges from the documented spec and from Pipeline B, undervolatilyzing salary variance in Pipeline A by 25%.",
+           "failure_scenario": "MC runs via Pipeline A will show narrower salary distributions than Pipeline B for the same inputs. CLAUDE.md rule
+       quoted verbatim: 'Salary growth: σ = max(0.5%, |rate| × 40%), floor = −5%'. Fixing: change `salary: { minimum: 0.005, multiplier: 0.3 }` to
+       `multiplier: 0.4` in stochasticSigmaForRate."
+         },
+         {
+           "file": "src/js/calculation/projection-cache.js",
+           "line": 1,
+           "summary": "Efficiency: ProjectionCache is an unbounded Map with no eviction policy. Each unique rawInput+policyVersion combination is cached
+       forever in the module-level projectionService singleton. On the advanced-v2 page every form change with 'useDetailedCashflow' toggled or slider
+       moved produces a new hash entry that is never released.",
+           "failure_scenario": "A user who spends a long session adjusting inputs accumulates hundreds of cached projections (each holding a full
+       simulation result including yearlyData arrays). On mobile devices or over a long session this can exhaust heap before a page refresh. A simple
+       fix is a max-size LRU or just clearing the cache when size exceeds a threshold (e.g., 50 entries)."
+         },
+         {
+           "file": "src/js/calculation/household-cashflow-engine.js",
+           "line": 59,
+           "summary": "Altitude: The super-first allocation path hard-codes `ENHANCED_CONFIG.CONCESSIONAL_CAP || 30000` as a fallback for the
+       concessional cap room calculation. This is the same value already guaranteed by config.js (CONCESSIONAL_CAP: 30000) but the pattern bypasses the
+       `policy-engine.js` cap resolution that already handles the SG rate, salary-sacrifice interactions, and carry-forward unused amounts.",
+           "failure_scenario": "If config.js is updated to 2026-27 legislation (e.g., a scheduled cap increase to $32,500), the super-first allocation
+       in household-cashflow-engine.js will continue to apply the old $30,000 cap because it reads the flat config key rather than going through the
+       policy engine's full concessional capacity calculation. The fix is to import `calculateConcessionalCapRoom` (or equivalent) from policy-engine.js
+       rather than reading the raw cap."
+         },
+         {
+           "file": "src/js/calculation/projection-service.js",
+           "line": 55,
+           "summary": "Simplification: The inputHash deliberately includes rawInput alongside canonicalInput (comment: 'transitional until
+       CanonicalInput covers every projection-relevant field'). However, both the rawInput object and the derivedCashflow are already derivable from
+       canonicalInput once the adapters are complete. Including rawInput in the hash means structurally equivalent inputs that arrive with different
+       key-name aliases (e.g., 'invReturn' vs 'investmentReturn') produce different hashes and bypass the cache, defeating its purpose.",
+           "failure_scenario": "Callers like handleScenarioBuilder construct projectionInput by spreading forwardProjection.engineInputs over form
+       fields. If the forward projection used 'investmentReturn' and the manual form uses 'invReturn', two identical economic scenarios will get
+       different hashes and both be computed and stored. The comment acknowledges this is temporary; the fix is tracking when adapters are complete and
+       removing rawInput from the hash at that point."
+         }
+       ]
+  ⎿  Done (55 tool uses · 93.6k tokens · 3m 45s)
+  ⎿  Referenced file src/js/reverse-ui.js
+  ⎿  Read tests/unit/reverse-scenario-engine.test.js (263 lines)
+  ⎿  Referenced file tests/unit/reverse-solver.test.js
+  ⎿  Referenced file src/js/reverse-planner.js
+  ⎿  Referenced file src/reverse.html
+  ⎿  Skills restored (code-review)
+

--- a/src/advanced-v2.html
+++ b/src/advanced-v2.html
@@ -355,6 +355,35 @@
             </div>
           </div>
 
+          <div class="subhead">Current household cashflow</div>
+          <div class="fields three">
+            <div class="field">
+              <label class="toggle" for="useDetailedCashflow">
+                <input id="useDetailedCashflow" type="checkbox" />
+                <span class="track"></span>
+                <span class="label">Model income minus current spending</span>
+              </label>
+              <div class="field-help">Enable this only after entering your complete current household spending. Otherwise the projection keeps using explicit contributions only and shows a warning.</div>
+            </div>
+            <div class="field">
+              <label class="field-label" for="currentMonthlyIncome"><span>After-tax household income</span><span class="hint">$/month</span></label>
+              <div class="field-input has-prefix"><span class="prefix">$</span><input id="currentMonthlyIncome" type="number" value="0" /><span class="suffix">/mo</span></div>
+              <div class="field-help">Leave at 0 to estimate take-home income from salary, salary sacrifice and private health cover.</div>
+            </div>
+            <div class="field">
+              <label class="field-label" for="currentMonthlyLivingCosts"><span>Total current household spending</span><span class="hint">$/month</span></label>
+              <div class="field-input has-prefix"><span class="prefix">$</span><input id="currentMonthlyLivingCosts" type="number" value="0" /><span class="suffix">/mo</span></div>
+              <div class="field-help">Include living, housing and healthcare costs. Exclude mortgage repayments, monthly investing and salary sacrifice because they are accounted for separately.</div>
+            </div>
+            <div class="field">
+              <label class="field-label" for="surplusAllocationMode"><span>Allocate calculated surplus</span></label>
+              <div class="field-input"><select id="surplusAllocationMode">
+                <option value="cash" selected>Cash / mortgage offset</option>
+                <option value="invest">Auto-invest in shares / ETFs</option>
+              </select></div>
+            </div>
+          </div>
+
           <div data-advanced="true">
             <div class="subhead">Super strategy</div>
             <div class="fields three">
@@ -1643,6 +1672,7 @@
 
       <div class="results-card">
         <div class="results-eyebrow"><span class="live-dot"></span> Live projection · today's $</div>
+        <div id="r-projection-warnings" hidden></div>
 
         <div class="hero-number">
           <span class="ccy">$</span><span id="r-paycheck">—</span>

--- a/src/js/advanced-v2.js
+++ b/src/js/advanced-v2.js
@@ -34,10 +34,32 @@ import {
   initializeTooltips,
 } from './utils.js';
 import { buildForwardProjectionPayload, storeForwardProjection } from './forward-projection-bridge.js';
+import { adaptAdvancedV2Input } from './calculation/input-adapters/advanced-v2-adapter.js';
+import { applyCanonicalCashflowToEngineInputs } from './calculation/canonical-engine-adapter.js';
+import { ProjectionService } from './calculation/projection-service.js';
 
 const simulator = new RetirementSimulator(ENHANCED_CONFIG);
 const { DEFAULTS } = ENHANCED_CONFIG;
 const riskProfiler = new RiskProfilingEngine(ENHANCED_CONFIG);
+const projectionService = new ProjectionService({
+  simulator,
+  adapter: adaptAdvancedV2Input,
+  engineInputBuilder: (rawInput, { canonicalInput, derivedCashflow }) => (
+    applyCanonicalCashflowToEngineInputs(
+      buildEngineInputs(rawInput),
+      canonicalInput,
+      derivedCashflow
+    )
+  ),
+  resultAdapter: adaptEngineOutput,
+  summaryBuilder: ({ canonicalInput, simulation, adaptedResult }) => ({
+    targetAnnualIncomeToday: canonicalInput.retirementTarget.targetAnnualIncomeToday,
+    monthlyRetirementIncomeToday: adaptedResult.monthlyPaycheck,
+    superAtRetirementToday: adaptedResult.superAtRetire,
+    estateAtLifespan: simulation.finalBalance,
+  }),
+  policyVersion: '2026.1',
+});
 
 const EXPERIENCE_MAP = {
   none: 0,
@@ -97,6 +119,7 @@ const APP_STATE = {
   engineInputs: null,
   simulation: null,
   adaptedResult: null,
+  projection: null,
   monteCarloResults: null,
   retirementAgeResult: null,
   stressTestResults: [],
@@ -1069,6 +1092,10 @@ function readInputs() {
     cash: num('cash'),
     stocks: num('stocks'),
     monthlyStockContrib: num('monthlyStockContrib'),
+    useDetailedCashflow: chk('useDetailedCashflow'),
+    currentMonthlyIncome: num('currentMonthlyIncome'),
+    currentMonthlyLivingCosts: num('currentMonthlyLivingCosts'),
+    surplusAllocationMode: val('surplusAllocationMode', 'cash'),
     salarySacrifice: num('salarySacrifice'),
     partnerSalarySacrifice: num('partnerSalarySacrifice'),
     employerRate: num('employerRate', 12),
@@ -1279,17 +1306,17 @@ function readInputs() {
 }
 
 function runEngine(inp) {
-  const engineInputs = profiler.measure('advanced-v2.input.buildEngineInputs', () => buildEngineInputs(inp));
-  const simulation = profiler.measure('advanced-v2.core.deterministicSimulation', () => simulator.simulateRetirement(engineInputs, false));
-
-  return profiler.measure('advanced-v2.post.adaptEngineOutput', () => adaptEngineOutput(inp, engineInputs, simulation));
+  return profiler.measure('advanced-v2.core.projectionService', () => (
+    projectionService.computeProjection(inp, { sourceCalculator: 'advanced-v2' }).adaptedResult
+  ));
 }
 
 function computeBaseState(inp = null) {
   const input = inp || profiler.measure('advanced-v2.input.readInputs', () => readInputs());
-  const engineInputs = profiler.measure('advanced-v2.input.buildEngineInputs', () => buildEngineInputs(input));
-  const simulation = profiler.measure('advanced-v2.core.deterministicSimulation', () => simulator.simulateRetirement(engineInputs, false));
-  const adaptedResult = profiler.measure('advanced-v2.post.adaptEngineOutput', () => adaptEngineOutput(input, engineInputs, simulation));
+  const projection = profiler.measure('advanced-v2.core.projectionService', () => (
+    projectionService.computeProjection(input, { sourceCalculator: 'advanced-v2' })
+  ));
+  const { engineInputs, simulation, adaptedResult } = projection;
 
   // Persist inputs to localStorage so the Reverse Planner can import them
   try {
@@ -1308,10 +1335,16 @@ function computeBaseState(inp = null) {
     monteCarloResults: APP_STATE?.monteCarloResults || null,
     recommendations: APP_STATE?.recommendations || null,
     stressTestResults: APP_STATE?.stressTestResults || null,
+    canonicalInput: projection.canonicalInput,
+    derivedCashflow: projection.derivedCashflow,
+    inputHash: projection.inputHash,
+    policyVersion: projection.policyVersion,
+    diagnostics: projection.diagnostics,
+    warnings: projection.warnings,
   });
   storeForwardProjection(projectionPayload);
 
-  return { input, engineInputs, simulation, adaptedResult };
+  return { input, engineInputs, simulation, adaptedResult, projection };
 }
 
 function buildInputSignature(input = {}) {
@@ -1391,6 +1424,7 @@ function syncAppState(baseState = computeBaseState()) {
   APP_STATE.engineInputs = baseState.engineInputs;
   APP_STATE.simulation = baseState.simulation;
   APP_STATE.adaptedResult = baseState.adaptedResult;
+  APP_STATE.projection = baseState.projection || null;
   APP_STATE.currentInputSignature = buildInputSignature(baseState.input);
   updateSecondaryAnalysisStaleStates();
   return baseState;
@@ -1651,6 +1685,16 @@ function normalizeImportedUserData(userData = {}) {
     cash: userData.currentSavings ?? userData.savings ?? base.cash,
     stocks: userData.currentStocks ?? userData.investments ?? base.stocks,
     monthlyStockContrib: userData.monthlyStockContribution ?? base.monthlyStockContrib,
+    useDetailedCashflow: Boolean(userData.useDetailedCashflow ?? userData.useDetailedExpenseInputs ?? base.useDetailedCashflow),
+    currentMonthlyIncome: userData.currentMonthlyIncome ?? base.currentMonthlyIncome,
+    currentMonthlyLivingCosts: userData.currentMonthlyTotalSpend
+      ?? (
+        (userData.currentMonthlyHousingCosts ?? 0)
+        + (userData.currentMonthlyLivingCosts ?? 0)
+        + ((userData.currentHealthcareCosts ?? 0) / 12)
+      )
+      ?? base.currentMonthlyLivingCosts,
+    surplusAllocationMode: userData.surplusAllocationMode ?? base.surplusAllocationMode,
     salarySacrifice: userData.yourAdditionalSuperContribution ?? base.salarySacrifice,
     partnerSalarySacrifice: userData.partnerAdditionalSuperContribution ?? base.partnerSalarySacrifice,
     employerRate: userData.employerSuperContributionRate !== undefined ? toDisplayPercent(userData.employerSuperContributionRate) : base.employerRate,
@@ -3898,6 +3942,18 @@ function clearResultsError() {
 }
 
 function paint(result, inp) {
+  const warningBox = $('r-projection-warnings');
+  const warnings = APP_STATE.projection?.warnings || [];
+  if (warningBox) {
+    warningBox.hidden = warnings.length === 0;
+    warningBox.style.cssText = 'margin:10px 0;padding:10px;border-radius:8px;background:var(--gold-soft,#fffbeb);border:1px solid var(--gold,#f59e0b);font-size:12px;color:var(--ink-2)';
+    warningBox.innerHTML = warnings.length
+      ? '<b>Projection input warning</b><ul style="margin:6px 0 0 18px">'
+        + warnings.map((warning) => '<li>' + escapeHtml(warning) + '</li>').join('')
+        + '</ul>'
+      : '';
+  }
+
   // Hero
   setText('r-paycheck', Math.round(result.monthlyPaycheck).toLocaleString('en-AU'));
   setText('r-retire-age', inp.retireAge);
@@ -4296,6 +4352,7 @@ export {
   applyHouseholdVisibility,
   applyImportedUserData,
   buildEngineInputs,
+  computeBaseState,
   calculateRichTargetAmount,
   calculateTargetBuilderTotal,
   getAsfaComfortableAmount,

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -34,6 +34,9 @@ import { buildStressedInputs, normaliseStressScenarioForTest } from './policy/st
 import { RetirementCostAnalyzer } from './retirement-cost-analyzer.js';
 import PersonalizedQuestionEngine from './personalized-qa-engine.js';
 import { buildForwardProjectionPayload, storeForwardProjection } from './forward-projection-bridge.js';
+import { adaptAdvancedClassicInput } from './calculation/input-adapters/advanced-classic-adapter.js';
+import { applyCanonicalCashflowToEngineInputs } from './calculation/canonical-engine-adapter.js';
+import { ProjectionService } from './calculation/projection-service.js';
 import {
     calculateConcessionalCapStatus,
     calculateEmployerSuper,
@@ -138,6 +141,7 @@ class RetirementCalculatorApp {
     constructor() {
         this.config = versionManager.getLatestConfig();
         this.simulator = new RetirementSimulator(this.config);
+        this.projectionService = this.createProjectionService();
         this.chartManager = null; // Will be lazy-loaded
         this.marketData = new MarketDataEngine();
         this.themeManager = new ThemeManager();
@@ -155,6 +159,7 @@ class RetirementCalculatorApp {
         this.currentOutcome = null; // Current outcome calculation results
         this.currentResilience = null; // Current resilience analysis results
         this.currentResults = null;
+        this.currentProjection = null;
         this.isCalculating = false;
         this.isImporting = false;
         this.lastCalculationHash = null; // dirty-flag: tracks inputs at last successful calculation
@@ -167,6 +172,7 @@ class RetirementCalculatorApp {
     reinitializeApp(config) {
         this.config = config;
         this.simulator = new RetirementSimulator(this.config);
+        this.projectionService = this.createProjectionService();
         this.scenarioMatrix = new ScenarioComparisonMatrix(this.simulator, this.config);
         this.personaIntelligence = new PersonaIntelligenceEngine(this.simulator, this.config);
         this.healthcareModeling = new HealthcareModelingEngine(this.config);
@@ -174,6 +180,22 @@ class RetirementCalculatorApp {
         this.onboardingWizard = new OnboardingWizard(this.config);
 
         debugLog(`Re-initialized app with config for version ${config.version}`);
+    }
+
+    createProjectionService() {
+        return new ProjectionService({
+            simulator: this.simulator,
+            adapter: adaptAdvancedClassicInput,
+            engineInputBuilder: (rawInput, { canonicalInput, derivedCashflow }) => (
+                applyCanonicalCashflowToEngineInputs(rawInput, canonicalInput, derivedCashflow)
+            ),
+            summaryBuilder: ({ canonicalInput, simulation }) => ({
+                targetAnnualIncomeToday: canonicalInput.retirementTarget.targetAnnualIncomeToday,
+                finalBalance: simulation.finalBalance,
+                retirementAge: canonicalInput.household.retirementAge,
+            }),
+            policyVersion: this.config.version || 'unversioned',
+        });
     }
 
     handleVersionChange(newVersion) {
@@ -1188,6 +1210,14 @@ class RetirementCalculatorApp {
                 errors.push(`${label} cannot be negative.`);
             }
         }
+        if (
+            inputs.useDetailedExpenseInputs
+            && (Number(inputs.currentMonthlyHousingCosts || 0)
+                + Number(inputs.currentMonthlyLivingCosts || 0)
+                + (Number(inputs.currentHealthcareCosts || 0) / 12)) <= 0
+        ) {
+            errors.push('Enter current household expenses before enabling explicit monthly expense inputs.');
+        }
 
         // Percentage fields — must be 0–100 when expressed as decimal (0–1)
         const percentFields = [
@@ -1268,7 +1298,11 @@ class RetirementCalculatorApp {
 
             let result;
             try {
-                result = profiler.measure('advanced-classic.core.deterministicSimulation', () => this.simulator.simulateRetirement(inputs, false));
+                const projection = profiler.measure('advanced-classic.core.projectionService', () => (
+                    this.projectionService.computeProjection(inputs, { sourceCalculator: 'advanced' })
+                ));
+                result = projection.simulation;
+                this.currentProjection = projection;
                 this.currentResults = result;
                 this.refreshAllDerivedDefaults({ depletionAge: result.depletionAge });
             } catch (simError) {
@@ -1351,6 +1385,12 @@ class RetirementCalculatorApp {
                     simulation: result,
                     adaptedResult,
                     recommendations: this.currentOutcomeActions || null,
+                    canonicalInput: this.currentProjection?.canonicalInput || null,
+                    derivedCashflow: this.currentProjection?.derivedCashflow || null,
+                    inputHash: this.currentProjection?.inputHash || null,
+                    policyVersion: this.currentProjection?.policyVersion || null,
+                    diagnostics: this.currentProjection?.diagnostics || null,
+                    warnings: this.currentProjection?.warnings || [],
                 });
                 storeForwardProjection(projectionPayload);
             } catch {

--- a/src/js/calculation/canonical-engine-adapter.js
+++ b/src/js/calculation/canonical-engine-adapter.js
@@ -1,0 +1,34 @@
+export function applyCanonicalCashflowToEngineInputs(
+    baseEngineInputs,
+    canonicalInput,
+    derivedCashflow
+) {
+    const engineInputs = {
+        ...baseEngineInputs,
+        canonicalInputSchemaVersion: canonicalInput.schemaVersion,
+    };
+
+    if (!derivedCashflow?.canAllocateSurplus) return engineInputs;
+
+    const allocations = derivedCashflow.allocations;
+    engineInputs.useDetailedExpenseInputs = true;
+    engineInputs.currentMonthlyHousingCosts = canonicalInput.cashflow.currentMonthlyHousingCosts;
+    engineInputs.currentMonthlyLivingCosts = canonicalInput.cashflow.totalSpendProvided
+        ? canonicalInput.cashflow.currentMonthlyTotalSpend
+        : canonicalInput.cashflow.currentMonthlyLivingCosts;
+    engineInputs.currentHealthcareCosts = canonicalInput.cashflow.totalSpendProvided
+        ? 0
+        : canonicalInput.cashflow.currentMonthlyHealthcareCosts * 12;
+    engineInputs.annualCashSavingsContribution = allocations.cash;
+    engineInputs.monthlyStockContribution = (baseEngineInputs.monthlyStockContribution || 0)
+        + (allocations.stocks / 12);
+    engineInputs.monthlyMortgagePayment = derivedCashflow.baseMonthlyMortgagePayment
+        + (allocations.mortgage / 12);
+    engineInputs.yourAdditionalSuperContribution = (baseEngineInputs.yourAdditionalSuperContribution || 0)
+        + derivedCashflow.superByMember.primary;
+    engineInputs.partnerAdditionalSuperContribution = (baseEngineInputs.partnerAdditionalSuperContribution || 0)
+        + derivedCashflow.superByMember.partner;
+    engineInputs.surplusAllocationMode = canonicalInput.cashflow.surplusAllocationMode;
+    engineInputs.derivedAnnualSurplus = derivedCashflow.annualSurplus;
+    return engineInputs;
+}

--- a/src/js/calculation/canonical-input-schema.js
+++ b/src/js/calculation/canonical-input-schema.js
@@ -15,6 +15,8 @@ export function normaliseCanonicalInput(input = {}) {
         'currentMonthlyHousingCosts',
         'currentMonthlyLivingCosts',
     ].some((field) => Object.prototype.hasOwnProperty.call(cashflow, field));
+    const totalSpendProvided = cashflow.totalSpendProvided
+        ?? Object.prototype.hasOwnProperty.call(cashflow, 'currentMonthlyTotalSpend');
     return {
         schemaVersion: CANONICAL_INPUT_SCHEMA_VERSION,
         household: {
@@ -50,7 +52,7 @@ export function normaliseCanonicalInput(input = {}) {
         },
         cashflow: {
             hasDetailedExpenses: Boolean(hasDetailedExpenses),
-            totalSpendProvided: Object.prototype.hasOwnProperty.call(cashflow, 'currentMonthlyTotalSpend'),
+            totalSpendProvided: Boolean(totalSpendProvided),
             currentMonthlyIncome: number(cashflow.currentMonthlyIncome),
             currentMonthlyHousingCosts: number(cashflow.currentMonthlyHousingCosts),
             currentMonthlyLivingCosts: number(cashflow.currentMonthlyLivingCosts),
@@ -61,6 +63,7 @@ export function normaliseCanonicalInput(input = {}) {
             explicitAnnualSalarySacrifice: number(cashflow.explicitAnnualSalarySacrifice),
             partnerExplicitAnnualSalarySacrifice: number(cashflow.partnerExplicitAnnualSalarySacrifice),
             currentMonthlyMortgagePayment: number(cashflow.currentMonthlyMortgagePayment),
+            mortgageIncludedInSpending: Boolean(cashflow.mortgageIncludedInSpending),
             surplusAllocationMode: ['cash', 'invest', 'mortgage_first', 'super_first', 'custom_split'].includes(cashflow.surplusAllocationMode)
                 ? cashflow.surplusAllocationMode
                 : 'cash',

--- a/src/js/calculation/canonical-input-schema.js
+++ b/src/js/calculation/canonical-input-schema.js
@@ -44,6 +44,7 @@ export function normaliseCanonicalInput(input = {}) {
             stocksPortfolio: number(input.currentAssets?.stocksPortfolio),
             homeValue: number(input.currentAssets?.homeValue),
             mortgageBalance: number(input.currentAssets?.mortgageBalance),
+            mortgageRate: normaliseRate(input.currentAssets?.mortgageRate, 0),
             investmentPropertyValue: number(input.currentAssets?.investmentPropertyValue),
             investmentPropertyLoan: number(input.currentAssets?.investmentPropertyLoan),
         },

--- a/src/js/calculation/canonical-input-schema.js
+++ b/src/js/calculation/canonical-input-schema.js
@@ -1,0 +1,104 @@
+import { normaliseRate } from '../policy/normalise-inputs.js';
+
+export const CANONICAL_INPUT_SCHEMA_VERSION = 'calculator-input-v1';
+
+const number = (value, fallback = 0) => {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+export function normaliseCanonicalInput(input = {}) {
+    const householdType = input.household?.householdType === 'couple' ? 'couple' : 'single';
+    const cashflow = input.cashflow || {};
+    const hasDetailedExpenses = cashflow.hasDetailedExpenses ?? [
+        'currentMonthlyTotalSpend',
+        'currentMonthlyHousingCosts',
+        'currentMonthlyLivingCosts',
+    ].some((field) => Object.prototype.hasOwnProperty.call(cashflow, field));
+    return {
+        schemaVersion: CANONICAL_INPUT_SCHEMA_VERSION,
+        household: {
+            householdType,
+            currentAge: number(input.household?.currentAge, 50),
+            partnerAge: householdType === 'couple' ? number(input.household?.partnerAge, 50) : null,
+            retirementAge: number(input.household?.retirementAge, 67),
+            partnerRetirementAge: householdType === 'couple' ? number(input.household?.partnerRetirementAge, 67) : null,
+            lifespan: number(input.household?.lifespan, 90),
+            partnerLifespan: householdType === 'couple' ? number(input.household?.partnerLifespan, 90) : null,
+        },
+        income: {
+            annualSalary: number(input.income?.annualSalary),
+            partnerAnnualSalary: householdType === 'couple' ? number(input.income?.partnerAnnualSalary) : 0,
+            salaryIncomeMode: input.income?.salaryIncomeMode || 'gross',
+            partnerSalaryIncomeMode: input.income?.partnerSalaryIncomeMode || 'gross',
+            businessIncome: number(input.income?.businessIncome),
+            investmentIncomeOutsideSuper: number(input.income?.investmentIncomeOutsideSuper),
+            employerSuperAnnual: number(input.income?.employerSuperAnnual),
+            partnerEmployerSuperAnnual: householdType === 'couple' ? number(input.income?.partnerEmployerSuperAnnual) : 0,
+            hasPrivateHealthCover: input.income?.hasPrivateHealthCover !== false,
+        },
+        currentAssets: {
+            currentSuperBalance: number(input.currentAssets?.currentSuperBalance),
+            partnerCurrentSuperBalance: householdType === 'couple' ? number(input.currentAssets?.partnerCurrentSuperBalance) : 0,
+            cashSavings: number(input.currentAssets?.cashSavings),
+            stocksPortfolio: number(input.currentAssets?.stocksPortfolio),
+            homeValue: number(input.currentAssets?.homeValue),
+            mortgageBalance: number(input.currentAssets?.mortgageBalance),
+            investmentPropertyValue: number(input.currentAssets?.investmentPropertyValue),
+            investmentPropertyLoan: number(input.currentAssets?.investmentPropertyLoan),
+        },
+        cashflow: {
+            hasDetailedExpenses: Boolean(hasDetailedExpenses),
+            totalSpendProvided: Object.prototype.hasOwnProperty.call(cashflow, 'currentMonthlyTotalSpend'),
+            currentMonthlyIncome: number(cashflow.currentMonthlyIncome),
+            currentMonthlyHousingCosts: number(cashflow.currentMonthlyHousingCosts),
+            currentMonthlyLivingCosts: number(cashflow.currentMonthlyLivingCosts),
+            currentMonthlyHealthcareCosts: number(cashflow.currentMonthlyHealthcareCosts),
+            currentMonthlyTotalSpend: number(cashflow.currentMonthlyTotalSpend),
+            currentMonthlySurplus: cashflow.currentMonthlySurplus == null ? null : number(cashflow.currentMonthlySurplus),
+            explicitMonthlyInvestmentContribution: number(cashflow.explicitMonthlyInvestmentContribution),
+            explicitAnnualSalarySacrifice: number(cashflow.explicitAnnualSalarySacrifice),
+            partnerExplicitAnnualSalarySacrifice: number(cashflow.partnerExplicitAnnualSalarySacrifice),
+            currentMonthlyMortgagePayment: number(cashflow.currentMonthlyMortgagePayment),
+            surplusAllocationMode: ['cash', 'invest', 'mortgage_first', 'super_first', 'custom_split'].includes(cashflow.surplusAllocationMode)
+                ? cashflow.surplusAllocationMode
+                : 'cash',
+            surplusToCashMonthly: number(cashflow.surplusToCashMonthly),
+            surplusToStocksMonthly: number(cashflow.surplusToStocksMonthly),
+            surplusToSuperAnnual: number(cashflow.surplusToSuperAnnual),
+            surplusToMortgageMonthly: number(cashflow.surplusToMortgageMonthly),
+        },
+        retirementTarget: {
+            targetAnnualIncomeToday: number(input.retirementTarget?.targetAnnualIncomeToday),
+            targetIncomeTaxBasis: 'after_tax_today_dollars',
+            confidenceTarget: normaliseRate(input.retirementTarget?.confidenceTarget, 0.8),
+            minimumEstateToday: number(input.retirementTarget?.minimumEstateToday),
+        },
+        housingAndPension: {
+            primaryResidenceType: input.housingAndPension?.primaryResidenceType || 'own_home',
+            homeowner: Boolean(input.housingAndPension?.homeowner),
+            primaryRentMonthly: number(input.housingAndPension?.primaryRentMonthly),
+            includeAgePension: input.housingAndPension?.includeAgePension !== false,
+            pensionAssetThreshold: input.housingAndPension?.pensionAssetThreshold == null ? null : number(input.housingAndPension.pensionAssetThreshold),
+            pensionAssetCutoff: input.housingAndPension?.pensionAssetCutoff == null ? null : number(input.housingAndPension.pensionAssetCutoff),
+            pensionIncomeThreshold: input.housingAndPension?.pensionIncomeThreshold == null ? null : number(input.housingAndPension.pensionIncomeThreshold),
+        },
+        scenarioToggles: {
+            includeSuper: input.scenarioToggles?.includeSuper !== false,
+            includeNonSuperInvestments: input.scenarioToggles?.includeNonSuperInvestments !== false,
+            includeInvestmentProperty: Boolean(input.scenarioToggles?.includeInvestmentProperty),
+            sellInvestmentPropertyAtRetirement: Boolean(input.scenarioToggles?.sellInvestmentPropertyAtRetirement),
+            includeDownsizing: Boolean(input.scenarioToggles?.includeDownsizing),
+            includeAgedCare: Boolean(input.scenarioToggles?.includeAgedCare),
+            includeOverseasRetirement: Boolean(input.scenarioToggles?.includeOverseasRetirement),
+        },
+        assumptions: {
+            inflationRate: normaliseRate(input.assumptions?.inflationRate, 0.026),
+            wageGrowthRate: normaliseRate(input.assumptions?.wageGrowthRate, 0.02),
+            superReturnRate: normaliseRate(input.assumptions?.superReturnRate, 0.075),
+            investmentReturnRate: normaliseRate(input.assumptions?.investmentReturnRate, 0.065),
+            propertyGrowthRate: normaliseRate(input.assumptions?.propertyGrowthRate, 0.04),
+            retirementDrawdownRate: normaliseRate(input.assumptions?.retirementDrawdownRate, 0.04),
+        },
+    };
+}

--- a/src/js/calculation/household-cashflow-engine.js
+++ b/src/js/calculation/household-cashflow-engine.js
@@ -35,9 +35,11 @@ export function deriveHouseholdCashflow(canonicalInput) {
     const currentAnnualSpending = cashflow.totalSpendProvided
         ? annualise(cashflow.currentMonthlyTotalSpend)
         : annualise(cashflow.currentMonthlyHousingCosts + cashflow.currentMonthlyLivingCosts + cashflow.currentMonthlyHealthcareCosts);
-    const baseMonthlyMortgagePayment = cashflow.currentMonthlyMortgagePayment > 0
-        ? cashflow.currentMonthlyMortgagePayment
-        : calculateMonthlyLoanPayment(currentAssets.mortgageBalance, currentAssets.mortgageRate);
+    const baseMonthlyMortgagePayment = cashflow.mortgageIncludedInSpending
+        ? 0
+        : cashflow.currentMonthlyMortgagePayment > 0
+            ? cashflow.currentMonthlyMortgagePayment
+            : calculateMonthlyLoanPayment(currentAssets.mortgageBalance, currentAssets.mortgageRate);
     const annualMortgageRepayments = annualise(baseMonthlyMortgagePayment);
     const explicitInvestmentContributions = annualise(cashflow.explicitMonthlyInvestmentContribution);
     const canAllocateSurplus = cashflow.hasDetailedExpenses && currentAnnualSpending > 0;

--- a/src/js/calculation/household-cashflow-engine.js
+++ b/src/js/calculation/household-cashflow-engine.js
@@ -1,0 +1,130 @@
+import ENHANCED_CONFIG from '../config.js';
+import { calculatePostTaxIncome } from '../utils.js';
+
+const annualise = (monthly) => monthly * 12;
+
+export function deriveHouseholdCashflow(canonicalInput) {
+    const { household, income, cashflow, currentAssets } = canonicalInput;
+    const salarySacrifice = cashflow.explicitAnnualSalarySacrifice + cashflow.partnerExplicitAnnualSalarySacrifice;
+    const taxableSalary = Math.max(0, income.annualSalary - cashflow.explicitAnnualSalarySacrifice);
+    const partnerTaxableSalary = Math.max(0, income.partnerAnnualSalary - cashflow.partnerExplicitAnnualSalarySacrifice);
+    const otherIncome = income.businessIncome + income.investmentIncomeOutsideSuper;
+    const grossHouseholdIncome = income.annualSalary + income.partnerAnnualSalary + otherIncome;
+    const postTaxSalary = calculatePostTaxIncome(
+        taxableSalary,
+        ENHANCED_CONFIG.TAX_BRACKETS,
+        income.hasPrivateHealthCover
+    );
+    const partnerPostTaxSalary = calculatePostTaxIncome(
+        partnerTaxableSalary,
+        ENHANCED_CONFIG.TAX_BRACKETS,
+        income.hasPrivateHealthCover
+    );
+    const estimatedPostTaxIncome = Math.max(0, postTaxSalary + partnerPostTaxSalary + (otherIncome * 0.70));
+    const estimatedTax = Math.max(0, grossHouseholdIncome - salarySacrifice - estimatedPostTaxIncome);
+    const postTaxIncome = cashflow.currentMonthlyIncome > 0
+        ? annualise(cashflow.currentMonthlyIncome)
+        : estimatedPostTaxIncome;
+    const currentAnnualSpending = cashflow.totalSpendProvided
+        ? annualise(cashflow.currentMonthlyTotalSpend)
+        : annualise(cashflow.currentMonthlyHousingCosts + cashflow.currentMonthlyLivingCosts + cashflow.currentMonthlyHealthcareCosts);
+    const annualMortgageRepayments = annualise(cashflow.currentMonthlyMortgagePayment);
+    const explicitInvestmentContributions = annualise(cashflow.explicitMonthlyInvestmentContribution);
+    const annualSurplus = cashflow.hasDetailedExpenses
+        ? postTaxIncome - currentAnnualSpending - annualMortgageRepayments - explicitInvestmentContributions
+        : null;
+    const availableSurplus = Math.max(0, annualSurplus || 0);
+    const allocations = { cash: 0, stocks: 0, super: 0, mortgage: 0 };
+    const superByMember = { primary: 0, partner: 0 };
+
+    if (cashflow.surplusAllocationMode === 'invest') {
+        allocations.stocks = availableSurplus;
+    } else if (cashflow.surplusAllocationMode === 'mortgage_first') {
+        allocations.mortgage = Math.min(availableSurplus, currentAssets.mortgageBalance);
+        allocations.stocks = availableSurplus - allocations.mortgage;
+    } else if (cashflow.surplusAllocationMode === 'super_first') {
+        const concessionalCap = ENHANCED_CONFIG.CONCESSIONAL_CAP || 30000;
+        const primaryCapRoom = Math.max(
+            0,
+            concessionalCap - income.employerSuperAnnual - cashflow.explicitAnnualSalarySacrifice
+        );
+        const partnerCapRoom = household.householdType === 'couple'
+            ? Math.max(
+                0,
+                concessionalCap - income.partnerEmployerSuperAnnual - cashflow.partnerExplicitAnnualSalarySacrifice
+            )
+            : 0;
+        superByMember.primary = Math.min(availableSurplus, primaryCapRoom);
+        superByMember.partner = Math.min(
+            availableSurplus - superByMember.primary,
+            partnerCapRoom
+        );
+        allocations.super = superByMember.primary + superByMember.partner;
+        allocations.stocks = availableSurplus - allocations.super;
+    } else if (cashflow.surplusAllocationMode === 'custom_split') {
+        const requested = {
+            cash: annualise(cashflow.surplusToCashMonthly),
+            stocks: annualise(cashflow.surplusToStocksMonthly),
+            super: cashflow.surplusToSuperAnnual,
+            mortgage: Math.min(
+                annualise(cashflow.surplusToMortgageMonthly),
+                currentAssets.mortgageBalance
+            ),
+        };
+        const requestedTotal = Object.values(requested).reduce((sum, value) => sum + value, 0);
+        const scale = requestedTotal > 0 ? Math.min(1, availableSurplus / requestedTotal) : 0;
+        Object.keys(allocations).forEach((key) => {
+            allocations[key] = requested[key] * scale;
+        });
+    } else {
+        allocations.cash = availableSurplus;
+    }
+
+    const allocatedSurplus = Object.values(allocations).reduce((sum, value) => sum + value, 0);
+    const unallocatedSurplus = Math.max(0, availableSurplus - allocatedSurplus);
+    const warnings = [];
+    if (!cashflow.hasDetailedExpenses) warnings.push('Current household spending is missing, so no implicit surplus was allocated.');
+    if (annualSurplus !== null && annualSurplus < 0) warnings.push('Household spending and contributions exceed estimated post-tax income.');
+    const requestedCustomAllocation = annualise(cashflow.surplusToCashMonthly)
+        + annualise(cashflow.surplusToStocksMonthly)
+        + cashflow.surplusToSuperAnnual
+        + annualise(cashflow.surplusToMortgageMonthly);
+    if (cashflow.surplusAllocationMode === 'custom_split' && requestedCustomAllocation > availableSurplus + 0.01) {
+        warnings.push('Custom surplus allocations were capped at the available household surplus.');
+    }
+    if (
+        cashflow.surplusAllocationMode === 'custom_split'
+        && annualise(cashflow.surplusToMortgageMonthly) > currentAssets.mortgageBalance
+    ) {
+        warnings.push('Custom mortgage allocation was capped at the outstanding mortgage balance.');
+    }
+    if (cashflow.surplusAllocationMode === 'super_first') {
+        warnings.push('Super-first amounts require the projection adapter to model contribution tax and changed take-home pay.');
+    }
+    if (unallocatedSurplus > 0.01) warnings.push('Some household surplus is unallocated.');
+    if (otherIncome > 0) warnings.push('Business and non-super investment income uses the simulator simplified 30% tax assumption.');
+    if (
+        cashflow.currentMonthlySurplus !== null
+        && annualSurplus !== null
+        && Math.abs(cashflow.currentMonthlySurplus - (annualSurplus / 12)) > 1
+    ) {
+        warnings.push('The entered monthly surplus does not match derived household cashflow.');
+    }
+
+    return {
+        grossHouseholdIncome,
+        estimatedTax,
+        postTaxIncome,
+        currentAnnualSpending,
+        annualMortgageRepayments,
+        explicitSuperContributions: salarySacrifice,
+        explicitInvestmentContributions,
+        annualSurplus,
+        monthlySurplus: annualSurplus === null ? null : annualSurplus / 12,
+        allocations,
+        superByMember,
+        allocatedSurplus,
+        unallocatedSurplus,
+        warnings,
+    };
+}

--- a/src/js/calculation/household-cashflow-engine.js
+++ b/src/js/calculation/household-cashflow-engine.js
@@ -3,6 +3,13 @@ import { calculatePostTaxIncome } from '../utils.js';
 
 const annualise = (monthly) => monthly * 12;
 
+export function calculateMonthlyLoanPayment(balance, annualRate, months = 360) {
+    if (!(balance > 0) || !(months > 0)) return 0;
+    if (!(annualRate > 0)) return balance / months;
+    const monthlyRate = annualRate / 12;
+    return (balance * monthlyRate) / (1 - Math.pow(1 + monthlyRate, -months));
+}
+
 export function deriveHouseholdCashflow(canonicalInput) {
     const { household, income, cashflow, currentAssets } = canonicalInput;
     const salarySacrifice = cashflow.explicitAnnualSalarySacrifice + cashflow.partnerExplicitAnnualSalarySacrifice;
@@ -28,9 +35,13 @@ export function deriveHouseholdCashflow(canonicalInput) {
     const currentAnnualSpending = cashflow.totalSpendProvided
         ? annualise(cashflow.currentMonthlyTotalSpend)
         : annualise(cashflow.currentMonthlyHousingCosts + cashflow.currentMonthlyLivingCosts + cashflow.currentMonthlyHealthcareCosts);
-    const annualMortgageRepayments = annualise(cashflow.currentMonthlyMortgagePayment);
+    const baseMonthlyMortgagePayment = cashflow.currentMonthlyMortgagePayment > 0
+        ? cashflow.currentMonthlyMortgagePayment
+        : calculateMonthlyLoanPayment(currentAssets.mortgageBalance, currentAssets.mortgageRate);
+    const annualMortgageRepayments = annualise(baseMonthlyMortgagePayment);
     const explicitInvestmentContributions = annualise(cashflow.explicitMonthlyInvestmentContribution);
-    const annualSurplus = cashflow.hasDetailedExpenses
+    const canAllocateSurplus = cashflow.hasDetailedExpenses && currentAnnualSpending > 0;
+    const annualSurplus = canAllocateSurplus
         ? postTaxIncome - currentAnnualSpending - annualMortgageRepayments - explicitInvestmentContributions
         : null;
     const availableSurplus = Math.max(0, annualSurplus || 0);
@@ -84,6 +95,9 @@ export function deriveHouseholdCashflow(canonicalInput) {
     const unallocatedSurplus = Math.max(0, availableSurplus - allocatedSurplus);
     const warnings = [];
     if (!cashflow.hasDetailedExpenses) warnings.push('Current household spending is missing, so no implicit surplus was allocated.');
+    if (cashflow.hasDetailedExpenses && currentAnnualSpending <= 0) {
+        warnings.push('Current household spending must be greater than zero before surplus can be allocated.');
+    }
     if (annualSurplus !== null && annualSurplus < 0) warnings.push('Household spending and contributions exceed estimated post-tax income.');
     const requestedCustomAllocation = annualise(cashflow.surplusToCashMonthly)
         + annualise(cashflow.surplusToStocksMonthly)
@@ -115,7 +129,9 @@ export function deriveHouseholdCashflow(canonicalInput) {
         grossHouseholdIncome,
         estimatedTax,
         postTaxIncome,
+        canAllocateSurplus,
         currentAnnualSpending,
+        baseMonthlyMortgagePayment,
         annualMortgageRepayments,
         explicitSuperContributions: salarySacrifice,
         explicitInvestmentContributions,

--- a/src/js/calculation/input-adapters/advanced-classic-adapter.js
+++ b/src/js/calculation/input-adapters/advanced-classic-adapter.js
@@ -1,0 +1,88 @@
+import { normaliseCanonicalInput } from '../canonical-input-schema.js';
+
+function residenceType(input) {
+    if (input.primaryResidenceType === 'renting') return 'renting';
+    if (input.primaryResidenceType === 'family' || input.primaryResidenceType === 'other') return 'no_home';
+    if ((input.mortgageBalance || 0) > 0) return 'own_home_with_mortgage';
+    return input.homeowner === false ? 'no_home' : 'own_home';
+}
+
+export function adaptAdvancedClassicInput(input = {}) {
+    const isCouple = input.isCouple === true
+        || input.isSingleCalculation === false
+        || Number(input.partnerCurrentAge) > 0;
+    const primaryResidenceType = residenceType(input);
+    return normaliseCanonicalInput({
+        household: {
+            householdType: isCouple ? 'couple' : 'single',
+            currentAge: input.yourCurrentAge,
+            partnerAge: input.partnerCurrentAge,
+            retirementAge: input.retirementAge,
+            partnerRetirementAge: input.partnerRetirementAge,
+            lifespan: input.yourLifespan,
+            partnerLifespan: input.partnerLifespan,
+        },
+        income: {
+            annualSalary: input.yourSalary,
+            partnerAnnualSalary: input.partnerSalary,
+            salaryIncomeMode: 'gross',
+            partnerSalaryIncomeMode: 'gross',
+            businessIncome: input.businessIncome,
+            investmentIncomeOutsideSuper: input.investmentIncome,
+            employerSuperAnnual: input.employerSG,
+            partnerEmployerSuperAnnual: input.partnerEmployerSG,
+            hasPrivateHealthCover: input.hasPrivateHealthCover !== false,
+        },
+        currentAssets: {
+            currentSuperBalance: input.yourCurrentSuper,
+            partnerCurrentSuperBalance: input.partnerCurrentSuper,
+            cashSavings: input.currentSavings,
+            stocksPortfolio: input.currentStocks,
+            homeValue: input.homeValue,
+            mortgageBalance: input.mortgageBalance,
+            mortgageRate: input.mortgageRate,
+            investmentPropertyValue: input.investmentPropertyValue,
+            investmentPropertyLoan: input.investmentPropertyLoan,
+        },
+        cashflow: {
+            hasDetailedExpenses: Boolean(input.useDetailedExpenseInputs),
+            currentMonthlyHousingCosts: input.currentMonthlyHousingCosts,
+            currentMonthlyLivingCosts: input.currentMonthlyLivingCosts,
+            currentMonthlyHealthcareCosts: (input.currentHealthcareCosts || 0) / 12,
+            mortgageIncludedInSpending: true,
+            explicitMonthlyInvestmentContribution: input.monthlyStockContribution,
+            explicitAnnualSalarySacrifice: input.yourAdditionalSuperContribution,
+            partnerExplicitAnnualSalarySacrifice: input.partnerAdditionalSuperContribution,
+            surplusAllocationMode: input.surplusAllocationMode || 'cash',
+        },
+        retirementTarget: {
+            targetAnnualIncomeToday: input.asfaComfortable,
+            confidenceTarget: input.confidenceTarget,
+            minimumEstateToday: input.legacyGoal,
+        },
+        housingAndPension: {
+            primaryResidenceType,
+            homeowner: primaryResidenceType === 'own_home' || primaryResidenceType === 'own_home_with_mortgage',
+            primaryRentMonthly: input.primaryRentMonthly,
+            includeAgePension: input.includeAgePension !== false,
+            pensionAssetThreshold: input.pensionAssetThreshold,
+            pensionAssetCutoff: input.pensionAssetLimit,
+            pensionIncomeThreshold: input.pensionIncomeThreshold,
+        },
+        scenarioToggles: {
+            includeSuper: true,
+            includeNonSuperInvestments: true,
+            includeInvestmentProperty: input.hasInvestmentProperty,
+            includeDownsizing: input.planToDownsize,
+            includeAgedCare: (input.agedCareProbability || 0) > 0,
+            includeOverseasRetirement: input.goingOverseas,
+        },
+        assumptions: {
+            inflationRate: input.inflation,
+            wageGrowthRate: input.salaryGrowthRate,
+            superReturnRate: input.superReturn,
+            investmentReturnRate: input.investmentReturn,
+            propertyGrowthRate: input.propertyGrowthRate,
+        },
+    });
+}

--- a/src/js/calculation/input-adapters/advanced-v2-adapter.js
+++ b/src/js/calculation/input-adapters/advanced-v2-adapter.js
@@ -1,0 +1,121 @@
+import { normaliseCanonicalInput } from '../canonical-input-schema.js';
+import {
+    DEFAULT_MAX_CONTRIBUTION_BASE_PER_QUARTER,
+    EMPLOYER_SUPER_MODES,
+    SALARY_INCOME_MODES,
+    resolveEmployerSuper,
+} from '../../super-policy.js';
+
+export function adaptAdvancedV2Input(input = {}) {
+    const isCouple = input.household === 'couple';
+    const rawResidenceType = input.primaryResidenceType
+        || (input.mortgage > 0 ? 'own_with_mortgage' : 'own_outright');
+    const residenceType = rawResidenceType === 'own_with_mortgage' || rawResidenceType === 'own_mortgage'
+        ? 'own_home_with_mortgage'
+        : rawResidenceType === 'own_outright'
+            ? 'own_home'
+            : rawResidenceType === 'renting'
+                ? 'renting'
+                : 'no_home';
+    const homeowner = residenceType === 'own_home' || residenceType === 'own_home_with_mortgage';
+    const employerRate = Math.abs(Number(input.employerRate || 12)) > 1
+        ? Number(input.employerRate || 12) / 100
+        : Number(input.employerRate || 0.12);
+    const commonSuperOptions = {
+        sgRate: employerRate,
+        maxContributionBasePerQuarter: input.maxContributionBasePerQuarter
+            || DEFAULT_MAX_CONTRIBUTION_BASE_PER_QUARTER,
+        applyMaxContributionBase: input.applyMaxContributionBase !== false,
+    };
+    const primaryIncome = resolveEmployerSuper({
+        ...commonSuperOptions,
+        employmentIncome: input.salary || 0,
+        incomeMode: input.salaryIncomeMode || SALARY_INCOME_MODES.EXCLUDING_SUPER,
+        employerSuperMode: input.employerSuperMode || EMPLOYER_SUPER_MODES.CALCULATED,
+        employerSuperOverrideAmount: input.employerSuperOverrideAmount,
+    });
+    const partnerIncome = resolveEmployerSuper({
+        ...commonSuperOptions,
+        employmentIncome: isCouple ? (input.partnerSalary || 0) : 0,
+        incomeMode: input.partnerSalaryIncomeMode || input.salaryIncomeMode || SALARY_INCOME_MODES.EXCLUDING_SUPER,
+        employerSuperMode: isCouple
+            ? (input.partnerEmployerSuperMode || EMPLOYER_SUPER_MODES.CALCULATED)
+            : EMPLOYER_SUPER_MODES.CALCULATED,
+        employerSuperOverrideAmount: isCouple ? input.partnerEmployerSuperOverrideAmount : 0,
+    });
+
+    return normaliseCanonicalInput({
+        household: {
+            householdType: isCouple ? 'couple' : 'single',
+            currentAge: input.age,
+            partnerAge: input.partnerAge,
+            retirementAge: input.retireAge,
+            partnerRetirementAge: input.partnerRetireAge,
+            lifespan: input.lifespan,
+            partnerLifespan: input.partnerLifespan,
+        },
+        income: {
+            annualSalary: primaryIncome.cashSalary,
+            partnerAnnualSalary: partnerIncome.cashSalary,
+            salaryIncomeMode: 'gross',
+            partnerSalaryIncomeMode: 'gross',
+            businessIncome: input.businessIncome,
+            investmentIncomeOutsideSuper: input.investmentIncomeOutsideSuper,
+            employerSuperAnnual: primaryIncome.employerSG,
+            partnerEmployerSuperAnnual: partnerIncome.employerSG,
+            hasPrivateHealthCover: input.hasPrivateHospital !== false,
+        },
+        currentAssets: {
+            currentSuperBalance: input.superBal,
+            partnerCurrentSuperBalance: input.partnerSuperBal,
+            cashSavings: input.cash,
+            stocksPortfolio: input.stocks,
+            homeValue: input.homeValue,
+            mortgageBalance: input.mortgage,
+            investmentPropertyValue: input.ipValue,
+            investmentPropertyLoan: input.ipLoan,
+        },
+        cashflow: {
+            hasDetailedExpenses: Object.prototype.hasOwnProperty.call(input, 'currentMonthlyLivingCosts'),
+            currentMonthlyIncome: input.currentMonthlyIncome,
+            currentMonthlyTotalSpend: input.currentMonthlyLivingCosts,
+            currentMonthlyHealthcareCosts: (input.healthcareCost || 0) / 12,
+            currentMonthlyMortgagePayment: input.monthlyMortgagePayment,
+            explicitMonthlyInvestmentContribution: input.monthlyStockContrib,
+            explicitAnnualSalarySacrifice: input.salarySacrifice,
+            partnerExplicitAnnualSalarySacrifice: input.partnerSalarySacrifice,
+            surplusAllocationMode: input.surplusAllocationMode || 'cash',
+            surplusToCashMonthly: input.surplusToCashMonthly,
+            surplusToStocksMonthly: input.surplusToStocksMonthly,
+            surplusToSuperAnnual: input.surplusToSuperAnnual,
+            surplusToMortgageMonthly: input.surplusToMortgageMonthly,
+        },
+        retirementTarget: {
+            targetAnnualIncomeToday: input.desiredIncome,
+            confidenceTarget: input.confidenceTarget,
+            minimumEstateToday: input.legacyGoal,
+        },
+        housingAndPension: {
+            primaryResidenceType: residenceType,
+            homeowner,
+            primaryRentMonthly: input.primaryRentMonthly,
+            includeAgePension: input.includeAgePension !== false,
+            pensionAssetThreshold: input.pensionAssetThreshold,
+            pensionAssetCutoff: input.pensionAssetCutoff,
+        },
+        scenarioToggles: {
+            includeSuper: true,
+            includeNonSuperInvestments: true,
+            includeInvestmentProperty: input.investmentProperty,
+            includeDownsizing: input.downsizePlan === 'yes',
+            includeAgedCare: (input.agedCareProbability || 0) > 0,
+            includeOverseasRetirement: input.goingOverseas,
+        },
+        assumptions: {
+            inflationRate: input.inflation,
+            superReturnRate: input.superGrowth,
+            investmentReturnRate: input.invReturn,
+            propertyGrowthRate: input.ipGrowthRate,
+        },
+    });
+}

--- a/src/js/calculation/input-adapters/advanced-v2-adapter.js
+++ b/src/js/calculation/input-adapters/advanced-v2-adapter.js
@@ -72,11 +72,12 @@ export function adaptAdvancedV2Input(input = {}) {
             stocksPortfolio: input.stocks,
             homeValue: input.homeValue,
             mortgageBalance: input.mortgage,
+            mortgageRate: input.mortgageRate,
             investmentPropertyValue: input.ipValue,
             investmentPropertyLoan: input.ipLoan,
         },
         cashflow: {
-            hasDetailedExpenses: Object.prototype.hasOwnProperty.call(input, 'currentMonthlyLivingCosts'),
+            hasDetailedExpenses: Boolean(input.useDetailedCashflow),
             currentMonthlyIncome: input.currentMonthlyIncome,
             currentMonthlyTotalSpend: input.currentMonthlyLivingCosts,
             currentMonthlyHealthcareCosts: (input.healthcareCost || 0) / 12,

--- a/src/js/calculation/input-adapters/reverse-manual-adapter.js
+++ b/src/js/calculation/input-adapters/reverse-manual-adapter.js
@@ -1,0 +1,89 @@
+import { normaliseCanonicalInput } from '../canonical-input-schema.js';
+
+export function adaptReverseManualInput(input = {}) {
+    const isCouple = input.householdType === 'couple'
+        || input.isCouple === true
+        || input.isSingleCalculation === false
+        || Number(input.partnerAge ?? input.partnerCurrentAge) > 0;
+    const mortgageBalance = input.mortgageBalance || 0;
+    const homeowner = input.homeowner !== false;
+    const primaryResidenceType = homeowner
+        ? (mortgageBalance > 0 ? 'own_home_with_mortgage' : 'own_home')
+        : ((input.primaryRentMonthly || 0) > 0 ? 'renting' : 'no_home');
+
+    return normaliseCanonicalInput({
+        household: {
+            householdType: isCouple ? 'couple' : 'single',
+            currentAge: input.currentAge ?? input.yourCurrentAge,
+            partnerAge: input.partnerAge ?? input.partnerCurrentAge,
+            retirementAge: input.retirementAge,
+            partnerRetirementAge: input.partnerRetirementAge,
+            lifespan: input.lifespan ?? input.yourLifespan,
+            partnerLifespan: input.partnerLifespan,
+        },
+        income: {
+            annualSalary: input.annualSalary ?? input.yourSalary,
+            partnerAnnualSalary: input.partnerAnnualSalary ?? input.partnerSalary,
+            salaryIncomeMode: 'gross',
+            partnerSalaryIncomeMode: 'gross',
+            businessIncome: input.businessIncome,
+            investmentIncomeOutsideSuper: input.investmentIncome,
+            employerSuperAnnual: input.employerSG,
+            partnerEmployerSuperAnnual: input.partnerEmployerSG,
+            hasPrivateHealthCover: input.hasPrivateHealthCover !== false,
+        },
+        currentAssets: {
+            currentSuperBalance: input.currentSuperBalance ?? input.superBalance ?? input.yourCurrentSuper,
+            partnerCurrentSuperBalance: input.partnerSuperBalance ?? input.partnerCurrentSuper,
+            cashSavings: input.cashSavings ?? input.currentSavings,
+            stocksPortfolio: input.stocksPortfolio ?? input.currentStocks,
+            homeValue: input.homeValue,
+            mortgageBalance,
+            mortgageRate: input.mortgageRate,
+            investmentPropertyValue: input.investmentPropertyValue,
+            investmentPropertyLoan: input.investmentPropertyLoan,
+        },
+        cashflow: {
+            hasDetailedExpenses: Boolean(input.useDetailedCashflow || input.useDetailedExpenseInputs),
+            currentMonthlyIncome: input.currentMonthlyIncome,
+            currentMonthlyHousingCosts: input.currentMonthlyHousingCosts,
+            currentMonthlyLivingCosts: input.currentMonthlyLivingCosts,
+            currentMonthlyHealthcareCosts: (input.currentHealthcareCosts || 0) / 12,
+            currentMonthlyMortgagePayment: input.monthlyMortgagePayment,
+            explicitMonthlyInvestmentContribution: input.monthlyInvestment ?? input.monthlyStockContribution,
+            explicitAnnualSalarySacrifice: input.salarySacrifice ?? input.yourAdditionalSuperContribution,
+            partnerExplicitAnnualSalarySacrifice: input.partnerSalarySacrifice ?? input.partnerAdditionalSuperContribution,
+            surplusAllocationMode: input.surplusAllocationMode || 'cash',
+        },
+        retirementTarget: {
+            targetAnnualIncomeToday: input.targetAnnualIncomeToday ?? input.asfaComfortable,
+            confidenceTarget: input.confidenceTarget ?? input.successProbabilityTarget,
+            minimumEstateToday: input.minimumEstateToday ?? input.legacyGoal,
+        },
+        housingAndPension: {
+            primaryResidenceType,
+            homeowner,
+            primaryRentMonthly: input.primaryRentMonthly,
+            includeAgePension: input.includeAgePension !== false,
+            pensionAssetThreshold: input.pensionAssetThreshold,
+            pensionAssetCutoff: input.pensionAssetLimit,
+            pensionIncomeThreshold: input.pensionIncomeThreshold,
+        },
+        scenarioToggles: {
+            includeSuper: input.includeSuper !== false,
+            includeNonSuperInvestments: input.includeNonSuperInvestments !== false,
+            includeInvestmentProperty: Boolean(input.hasInvestmentProperty),
+            sellInvestmentPropertyAtRetirement: Boolean(input.sellInvestmentPropertyAtRetirement),
+            includeDownsizing: Boolean(input.planToDownsize),
+            includeAgedCare: Boolean(input.includeAgedCare),
+            includeOverseasRetirement: Boolean(input.goingOverseas),
+        },
+        assumptions: {
+            inflationRate: input.inflation,
+            wageGrowthRate: input.salaryGrowthRate,
+            superReturnRate: input.superReturn,
+            investmentReturnRate: input.investmentReturn,
+            propertyGrowthRate: input.propertyGrowthRate,
+        },
+    });
+}

--- a/src/js/calculation/projection-cache.js
+++ b/src/js/calculation/projection-cache.js
@@ -1,0 +1,18 @@
+export class ProjectionCache {
+    constructor() {
+        this.cache = new Map();
+    }
+
+    get(inputHash) {
+        return this.cache.get(inputHash);
+    }
+
+    set(inputHash, projection) {
+        this.cache.set(inputHash, projection);
+        return projection;
+    }
+
+    clear() {
+        this.cache.clear();
+    }
+}

--- a/src/js/calculation/projection-service.js
+++ b/src/js/calculation/projection-service.js
@@ -45,9 +45,10 @@ export class ProjectionService {
     }
 
     computeProjection(rawInput, options = {}) {
-        const canonicalInput = normaliseCanonicalInput(
-            this.adapter ? this.adapter(rawInput) : rawInput
-        );
+        const adaptedInput = this.adapter ? this.adapter(rawInput) : rawInput;
+        const canonicalInput = adaptedInput?.schemaVersion
+            ? adaptedInput
+            : normaliseCanonicalInput(adaptedInput);
         const sourceCalculator = options.sourceCalculator || 'advanced-v2';
         // rawInput remains part of the transitional hash until CanonicalInput covers
         // every projection-relevant field from all three calculators.

--- a/src/js/calculation/projection-service.js
+++ b/src/js/calculation/projection-service.js
@@ -1,0 +1,97 @@
+import { normaliseCanonicalInput } from './canonical-input-schema.js';
+import { deriveHouseholdCashflow } from './household-cashflow-engine.js';
+import { ProjectionCache } from './projection-cache.js';
+import { normaliseInputs } from '../policy/normalise-inputs.js';
+
+function stableStringify(value) {
+    if (Array.isArray(value)) return '[' + value.map(stableStringify).join(',') + ']';
+    if (value && typeof value === 'object') {
+        return '{' + Object.keys(value).sort()
+            .map((key) => JSON.stringify(key) + ':' + stableStringify(value[key]))
+            .join(',') + '}';
+    }
+    return JSON.stringify(value);
+}
+
+export function hashProjectionInput(value) {
+    const text = stableStringify(value);
+    let hash = 2166136261;
+    for (let index = 0; index < text.length; index += 1) {
+        hash ^= text.charCodeAt(index);
+        hash = Math.imul(hash, 16777619);
+    }
+    return 'fnv1a-' + (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+export class ProjectionService {
+    constructor({
+        simulator,
+        adapter,
+        engineInputBuilder,
+        resultAdapter,
+        summaryBuilder,
+        cache = new ProjectionCache(),
+        policyVersion = 'unversioned',
+    }) {
+        if (!simulator?.simulateRetirement) throw new TypeError('ProjectionService requires a simulator.');
+        if (typeof engineInputBuilder !== 'function') throw new TypeError('ProjectionService requires an engineInputBuilder.');
+        this.simulator = simulator;
+        this.adapter = adapter;
+        this.engineInputBuilder = engineInputBuilder;
+        this.resultAdapter = resultAdapter;
+        this.summaryBuilder = summaryBuilder;
+        this.cache = cache;
+        this.policyVersion = policyVersion;
+    }
+
+    computeProjection(rawInput, options = {}) {
+        const canonicalInput = normaliseCanonicalInput(
+            this.adapter ? this.adapter(rawInput) : rawInput
+        );
+        const sourceCalculator = options.sourceCalculator || 'advanced-v2';
+        // rawInput remains part of the transitional hash until CanonicalInput covers
+        // every projection-relevant field from all three calculators.
+        const inputHash = hashProjectionInput({
+            policyVersion: this.policyVersion,
+            canonicalInput,
+            rawInput,
+        });
+        const cached = this.cache.get(inputHash);
+        if (cached) return cached;
+
+        const derivedCashflow = deriveHouseholdCashflow(canonicalInput);
+        const engineInputs = normaliseInputs(
+            this.engineInputBuilder(rawInput, { canonicalInput, derivedCashflow })
+        );
+        const simulation = this.simulator.simulateRetirement(engineInputs, false);
+        const adaptedResult = this.resultAdapter
+            ? this.resultAdapter(rawInput, engineInputs, simulation)
+            : simulation;
+        const summary = this.summaryBuilder
+            ? this.summaryBuilder({ canonicalInput, engineInputs, simulation, adaptedResult })
+            : {
+                finalBalance: simulation?.finalBalance ?? null,
+                retirementAge: canonicalInput.household.retirementAge,
+                targetAnnualIncomeToday: canonicalInput.retirementTarget.targetAnnualIncomeToday,
+            };
+        const projection = {
+            inputHash,
+            policyVersion: this.policyVersion,
+            schemaVersion: canonicalInput.schemaVersion,
+            sourceCalculator,
+            canonicalInput,
+            derivedCashflow,
+            engineInputs,
+            simulation,
+            adaptedResult,
+            yearlyData: simulation?.yearlyData || adaptedResult?.years || [],
+            summary,
+            diagnostics: {
+                deterministicRuns: 1,
+                rawInputIncludedInHash: true,
+            },
+            warnings: [...derivedCashflow.warnings],
+        };
+        return this.cache.set(inputHash, projection);
+    }
+}

--- a/src/js/calculation/reverse-scenario-engine.js
+++ b/src/js/calculation/reverse-scenario-engine.js
@@ -1,0 +1,193 @@
+import { ReverseRetirementSolver } from '../reverse-solver.js';
+import { applyTargetToEngineInputs } from '../reverse-success-predicate.js';
+
+const findLever = (levers, key) => levers.find((lever) => lever.lever === key);
+
+export class ReverseScenarioEngine {
+    constructor(config, { solver = null } = {}) {
+        this.config = config;
+        this.solver = solver || new ReverseRetirementSolver(config);
+    }
+
+    buildScenarioDefinitions(selected = {}) {
+        const base = {
+            includeSuper: selected.includeSuper !== false,
+            includeAgePension: selected.includeAgePension !== false,
+            includeNonSuperInvestments: selected.includeNonSuperInvestments !== false,
+            homeStatus: selected.homeStatus || 'own_home',
+            includeInvestmentProperty: Boolean(selected.includeInvestmentProperty),
+            sellInvestmentPropertyAtRetirement: Boolean(selected.sellInvestmentPropertyAtRetirement),
+            includeDownsizing: Boolean(selected.includeDownsizing),
+            includeAgedCare: Boolean(selected.includeAgedCare),
+            includeOverseasRetirement: Boolean(selected.includeOverseasRetirement),
+            stress: false,
+            noCurrentAssets: false,
+        };
+        return [
+            { key: 'selected', name: 'Selected plan', ...base },
+            { key: 'home_super_pension', name: 'Own home + super + Age Pension', ...base, homeStatus: 'own_home', includeSuper: true, includeAgePension: true, includeInvestmentProperty: false },
+            { key: 'home_super_private', name: 'Own home + super + no Age Pension', ...base, homeStatus: 'own_home', includeSuper: true, includeAgePension: false },
+            { key: 'renter_super_pension', name: 'Renting + super + Age Pension', ...base, homeStatus: 'renting', includeSuper: true, includeAgePension: true },
+            { key: 'non_super_only', name: 'Own home + non-super investments only', ...base, homeStatus: 'own_home', includeSuper: false, includeNonSuperInvestments: true },
+            { key: 'property_retained', name: 'Investment property retained', ...base, includeInvestmentProperty: true, sellInvestmentPropertyAtRetirement: false },
+            { key: 'property_sold', name: 'Investment property sold at retirement', ...base, includeInvestmentProperty: true, sellInvestmentPropertyAtRetirement: true },
+            { key: 'salary_only', name: 'No current assets — salary and savings path', ...base, noCurrentAssets: true },
+            { key: 'aged_care', name: 'Aged-care-adjusted plan', ...base, includeAgedCare: true },
+            { key: 'stress', name: 'Conservative return / high inflation stress', ...base, stress: true },
+        ];
+    }
+
+    applyScenario(baseEngineInputs, target, scenario) {
+        const inputs = { ...baseEngineInputs };
+        const yearsToRetirement = Math.max(
+            0,
+            (target.retirementAge || inputs.retirementAge || 67) - (inputs.yourCurrentAge || 50)
+        );
+
+        if (!scenario.includeSuper) {
+            inputs.yourCurrentSuper = 0;
+            inputs.partnerCurrentSuper = 0;
+            inputs.yourAdditionalSuperContribution = 0;
+            inputs.partnerAdditionalSuperContribution = 0;
+            inputs.employerSuperContributionRate = 0;
+            inputs.superContributionRate = 0;
+        }
+        if (!scenario.includeNonSuperInvestments) {
+            inputs.currentSavings = 0;
+            inputs.currentStocks = 0;
+            inputs.monthlyStockContribution = 0;
+            inputs.annualCashSavingsContribution = 0;
+        }
+        inputs.suppressAgePension = scenario.includeAgePension === false;
+
+        const isRenter = scenario.homeStatus === 'renting';
+        const hasHome = scenario.homeStatus === 'own_home'
+            || scenario.homeStatus === 'own_home_with_mortgage';
+        inputs.homeowner = hasHome;
+        inputs.ownsHome = hasHome;
+        inputs.primaryResidenceType = scenario.homeStatus;
+        inputs.homeValue = hasHome ? (inputs.homeValue || 0) : 0;
+        inputs.mortgageBalance = scenario.homeStatus === 'own_home_with_mortgage'
+            ? (inputs.mortgageBalance || 0)
+            : 0;
+        inputs.monthlyMortgagePayment = inputs.mortgageBalance > 0
+            ? (inputs.monthlyMortgagePayment || 0)
+            : 0;
+        if (!isRenter) {
+            inputs.primaryRentMonthly = 0;
+            inputs.primaryRentAnnual = 0;
+        }
+        const isCouple = inputs.isCouple || inputs.isSingleCalculation === false;
+        if (hasHome) {
+            inputs.pensionAssetThreshold = isCouple
+                ? this.config.COUPLE_ASSET_THRESHOLD
+                : this.config.SINGLE_ASSET_THRESHOLD;
+            inputs.pensionAssetLimit = isCouple
+                ? this.config.COUPLE_ASSET_LIMIT
+                : this.config.SINGLE_ASSET_LIMIT;
+        } else {
+            inputs.pensionAssetThreshold = isCouple
+                ? this.config.COUPLE_ASSET_THRESHOLD_NON_HOMEOWNER
+                : this.config.SINGLE_ASSET_THRESHOLD_NON_HOMEOWNER;
+            inputs.pensionAssetLimit = isCouple
+                ? this.config.COUPLE_ASSET_LIMIT_NON_HOMEOWNER
+                : this.config.SINGLE_ASSET_LIMIT_NON_HOMEOWNER;
+        }
+
+        inputs.hasInvestmentProperty = scenario.includeInvestmentProperty;
+        if (!scenario.includeInvestmentProperty) {
+            inputs.investmentPropertyValue = 0;
+            inputs.investmentPropertyLoan = 0;
+            inputs.weeklyRentalIncome = 0;
+            inputs.annualPropertyExpenses = 0;
+        } else if (scenario.sellInvestmentPropertyAtRetirement) {
+            inputs.sellPropertyYears = yearsToRetirement;
+        }
+
+        inputs.planToDownsize = scenario.includeDownsizing;
+        if (!scenario.includeAgedCare) {
+            inputs.agedCareProbability = 0;
+            inputs.agedCareAnnualCost = 0;
+        } else {
+            inputs.agedCareProbability = inputs.agedCareProbability || 1;
+            inputs.agedCareAnnualCost = inputs.agedCareAnnualCost || 60000;
+            inputs.agedCareStartAge = inputs.agedCareStartAge || 85;
+            inputs.agedCareDuration = inputs.agedCareDuration || 3;
+        }
+        inputs.goingOverseas = scenario.includeOverseasRetirement;
+        if (scenario.stress) {
+            inputs.investmentReturn = Math.max(0, (inputs.investmentReturn || 0.07) - 0.02);
+            inputs.superReturn = Math.max(0, (inputs.superReturn || 0.075) - 0.02);
+            inputs.inflation = (inputs.inflation || 0.026) + 0.02;
+        }
+        if (scenario.noCurrentAssets) {
+            inputs.yourCurrentSuper = 0;
+            inputs.partnerCurrentSuper = 0;
+            inputs.currentSavings = 0;
+            inputs.currentStocks = 0;
+            inputs.investmentPropertyValue = 0;
+            inputs.investmentPropertyLoan = 0;
+        }
+
+        const scenarioTarget = {
+            ...target,
+            includeAgePension: scenario.includeAgePension,
+        };
+        return {
+            inputs: applyTargetToEngineInputs(inputs, scenarioTarget, {
+                suppressAgePension: scenario.includeAgePension === false,
+            }),
+            target: scenarioTarget,
+        };
+    }
+
+    async solveScenario(baseEngineInputs, target, scenario, options = {}) {
+        const adjusted = this.applyScenario(baseEngineInputs, target, scenario);
+        const solved = await this.solver.solveAllLevers(
+            adjusted.inputs,
+            adjusted.target,
+            options
+        );
+        const levers = solved.rankedLevers || [];
+        const retirementRow = (solved.currentResult?.yearlyData || []).find(
+            (row) => row.age >= adjusted.target.retirementAge
+        );
+        const warnings = [
+            'Confidence target requires Monte Carlo validation and is not used by deterministic lever solves.',
+        ];
+        ['superBalance', 'investmentBalance', 'salary', 'extraSavings', 'extraAnnualSuper']
+            .forEach((key) => {
+                const lever = findLever(levers, key);
+                if (lever && !lever.feasible) warnings.push(lever.label + ' is not feasible as a single lever.');
+            });
+
+        return {
+            scenarioKey: scenario.key,
+            scenarioName: scenario.name,
+            requiredCurrentSuper: findLever(levers, 'superBalance')?.solved ?? null,
+            requiredCurrentNonSuperInvestments: findLever(levers, 'investmentBalance')?.solved ?? null,
+            requiredCurrentGrossSalary: findLever(levers, 'salary')?.solved ?? null,
+            requiredMonthlySurplus: findLever(levers, 'extraSavings')?.solved ?? null,
+            requiredAnnualSalarySacrifice: findLever(levers, 'extraAnnualSuper')?.solved ?? null,
+            requiredPropertyEquityOrRentalIncome: findLever(levers, 'netRent')?.solved ?? null,
+            expectedAgePensionContribution: retirementRow?.pensionIncome || 0,
+            expectedAssetsAtRetirement: solved.currentScore?.totalAssetsNominal || 0,
+            expectedEstateAtLifespan: solved.currentScore?.estateToday || 0,
+            meetsGoal: Boolean(solved.currentScore?.passesGoal),
+            warnings,
+            inputs: adjusted.inputs,
+            target: adjusted.target,
+        };
+    }
+
+    async compareScenarios(baseEngineInputs, target, selected = {}, options = {}) {
+        const definitions = this.buildScenarioDefinitions(selected);
+        const results = [];
+        for (const definition of definitions) {
+            results.push(await this.solveScenario(baseEngineInputs, target, definition, options));
+        }
+        return results;
+    }
+}
+
+export default ReverseScenarioEngine;

--- a/src/js/field-tooltips.js
+++ b/src/js/field-tooltips.js
@@ -114,6 +114,22 @@ const FIELD_TOOLTIP_DEFINITIONS = {
         title: 'Monthly investing',
         body: 'Extra monthly investing outside super builds non-super assets that can bridge the years before super or pension access.',
     },
+    useDetailedCashflow: {
+        title: 'Model current household cashflow',
+        body: 'Enable this after entering complete current spending. The calculator then allocates income left after tax, spending, mortgage repayments and explicit contributions.',
+    },
+    currentMonthlyIncome: {
+        title: 'After-tax household income',
+        body: 'Enter actual monthly take-home income, or leave this at zero so the calculator estimates take-home income from salary and salary sacrifice.',
+    },
+    currentMonthlyLivingCosts: {
+        title: 'Total current household spending',
+        body: 'Include current living, housing and healthcare spending, but exclude mortgage repayments and explicit investment or super contributions.',
+    },
+    surplusAllocationMode: {
+        title: 'Calculated surplus destination',
+        body: 'Choose whether the household surplus derived from current cashflow accumulates in cash or is invested outside super.',
+    },
     salarySacrifice: {
         title: 'Your salary sacrifice',
         body: 'Extra pre-tax super contributions can improve retirement savings and tax efficiency, but they count toward the concessional cap.',

--- a/src/js/forward-projection-bridge.js
+++ b/src/js/forward-projection-bridge.js
@@ -15,6 +15,12 @@ export function buildForwardProjectionPayload({
   monteCarloResults = null,
   recommendations = null,
   stressTestResults = null,
+  canonicalInput = null,
+  derivedCashflow = null,
+  inputHash = null,
+  policyVersion = null,
+  diagnostics = null,
+  warnings = [],
 }) {
   const retirementAge = input?.retireAge || input?.retirementAge || engineInputs?.retirementAge || 65;
   const currentAge = input?.age || input?.yourCurrentAge || engineInputs?.yourCurrentAge || 50;
@@ -43,6 +49,10 @@ export function buildForwardProjectionPayload({
     source,
     savedAt: new Date().toISOString(),
     input,
+    inputHash,
+    policyVersion,
+    canonicalInput,
+    derivedCashflow,
     engineInputs,
     simulation,
     adaptedResult,
@@ -50,6 +60,8 @@ export function buildForwardProjectionPayload({
     monteCarloResults,
     recommendations,
     stressTestResults,
+    diagnostics,
+    warnings,
     summary: {
       targetAnnualIncomeToday: input?.desiredIncome || input?.asfaComfortable || 0,
       monthlyRetirementIncomeToday: monthlyPaycheck,

--- a/src/js/forward-projection-bridge.js
+++ b/src/js/forward-projection-bridge.js
@@ -46,6 +46,7 @@ export function buildForwardProjectionPayload({
 
   const payload = {
     version: 1,
+    schemaVersion: canonicalInput?.schemaVersion || null,
     source,
     savedAt: new Date().toISOString(),
     input,

--- a/src/js/reverse-planner.js
+++ b/src/js/reverse-planner.js
@@ -64,8 +64,15 @@ export function normaliseReversePlannerInputs(rawInputs) {
     return {
         // Identity
         yourCurrentAge: num(rawInputs.currentAge ?? rawInputs.yourCurrentAge, 50),
+        partnerCurrentAge: isCouple ? num(rawInputs.partnerAge ?? rawInputs.partnerCurrentAge, 50) : 0,
         retirementAge: num(rawInputs.retirementAge, 67),
+        partnerRetirementAge: isCouple
+            ? num(rawInputs.partnerRetirementAge ?? rawInputs.retirementAge, 67)
+            : 0,
         yourLifespan: num(rawInputs.lifespan ?? rawInputs.yourLifespan, 90),
+        partnerLifespan: isCouple
+            ? num(rawInputs.partnerLifespan ?? rawInputs.lifespan ?? rawInputs.yourLifespan, 90)
+            : 0,
         isCouple,
         isSingleCalculation: !isCouple,
 

--- a/src/js/reverse-planner.js
+++ b/src/js/reverse-planner.js
@@ -142,7 +142,6 @@ export class ReversePlanner {
 
         const score = scoreScenario(simResult, target, inflationRate, ytr, swr);
 
-        g.normalizedValue = totalAchieved > 0 ? g.achievedValue / totalAchieved : 0;
         const yearlyData = simResult?.yearlyData || [];
         const retirementRowIndex = yearlyData.findIndex(row => row.age >= baseInputs.retirementAge);
         const retirementRow = retirementRowIndex >= 0 ? yearlyData[retirementRowIndex] : null;

--- a/src/js/reverse-planner.js
+++ b/src/js/reverse-planner.js
@@ -30,6 +30,9 @@ import {
     loadForwardProjection,
     extractCurrentPathFromProjection,
 } from './forward-projection-bridge.js';
+import { adaptReverseManualInput } from './calculation/input-adapters/reverse-manual-adapter.js';
+import { applyCanonicalCashflowToEngineInputs } from './calculation/canonical-engine-adapter.js';
+import { ProjectionService } from './calculation/projection-service.js';
 
 const DEFAULT_SWR = 0.04;
 const DEFAULT_INFLATION = ENHANCED_CONFIG.INFLATION_RATE || 0.026;
@@ -119,6 +122,26 @@ export class ReversePlanner {
         this.config = config;
         this.simulator = new RetirementSimulator(config);
         this.solver = new ReverseRetirementSolver(config);
+        this.projectionService = new ProjectionService({
+            simulator: this.simulator,
+            adapter: adaptReverseManualInput,
+            engineInputBuilder: (rawInput, { canonicalInput, derivedCashflow }) => {
+                const baseEngineInputs = Number.isFinite(rawInput.yourCurrentAge)
+                    ? { ...rawInput }
+                    : normaliseReversePlannerInputs(rawInput);
+                return applyCanonicalCashflowToEngineInputs(
+                    baseEngineInputs,
+                    canonicalInput,
+                    derivedCashflow
+                );
+            },
+            summaryBuilder: ({ canonicalInput, simulation }) => ({
+                targetAnnualIncomeToday: canonicalInput.retirementTarget.targetAnnualIncomeToday,
+                finalBalance: simulation.finalBalance,
+                retirementAge: canonicalInput.household.retirementAge,
+            }),
+            policyVersion: config.version || '2026.1',
+        });
     }
 
     /**
@@ -128,16 +151,18 @@ export class ReversePlanner {
      * @param {object} target      Target object
      * @returns {object}           currentPath with scores and gaps
      */
-    buildCurrentPath(baseInputs, target) {
+    buildCurrentPath(baseInputs, target, suppliedSimulation = null) {
         const inflationRate = baseInputs.inflation ?? DEFAULT_INFLATION;
         const swr = target.swr ?? DEFAULT_SWR;
         const ytr = Math.max(1, (baseInputs.retirementAge || 67) - (baseInputs.yourCurrentAge || 50));
 
-        let simResult;
-        try {
-            simResult = this.simulator.simulateRetirement(baseInputs, false);
-        } catch (err) {
-            throw new Error(`Current path simulation failed: ${err.message}`);
+        let simResult = suppliedSimulation;
+        if (!simResult) {
+            try {
+                simResult = this.simulator.simulateRetirement(baseInputs, false);
+            } catch (err) {
+                throw new Error(`Current path simulation failed: ${err.message}`);
+            }
         }
 
         const score = scoreScenario(simResult, target, inflationRate, ytr, swr);
@@ -236,8 +261,30 @@ export class ReversePlanner {
 
         // 1. Build current path
         let currentPath;
-        const projection = loadForwardProjection();
-        if (projection?.summary) {
+        const loadedProjection = loadForwardProjection();
+        const hasCompleteProjection = Boolean(
+            loadedProjection?.inputHash
+            && loadedProjection?.canonicalInput?.schemaVersion
+            && loadedProjection?.engineInputs
+            && loadedProjection?.simulation
+        );
+        const projectionInput = loadedProjection?.engineInputs
+            ? {
+                ...loadedProjection.engineInputs,
+                asfaComfortable: resolvedTarget.targetAnnualIncomeToday,
+                targetAnnualIncomeToday: resolvedTarget.targetAnnualIncomeToday,
+            }
+            : {
+                ...rawInputs,
+                targetAnnualIncomeToday: resolvedTarget.targetAnnualIncomeToday,
+            };
+        const projection = hasCompleteProjection
+            ? loadedProjection
+            : this.projectionService.computeProjection(projectionInput, {
+                sourceCalculator: 'reverse-manual',
+            });
+
+        if (hasCompleteProjection && projection?.summary) {
             currentPath = extractCurrentPathFromProjection(projection, {
                 retirementAge: resolvedTarget.retirementAge,
                 targetAnnualIncomeToday: resolvedTarget.targetAnnualIncomeToday,
@@ -270,16 +317,16 @@ export class ReversePlanner {
                 capitalGap: currentPath.capitalGap,
             };
         } else {
-            currentPath = this.buildCurrentPath(baseInputs, resolvedTarget);
+            currentPath = this.buildCurrentPath(
+                projection.engineInputs,
+                resolvedTarget,
+                projection.simulation
+            );
         }
 
         // 2. Run all lever solvers with engine predicate
         // Use projection.engineInputs as base when available (per spec Phase 9).
-        const hasEngineInputs = projection?.engineInputs
-            && typeof projection.engineInputs === 'object'
-            && Object.keys(projection.engineInputs).length > 0
-            && (Number.isFinite(projection.engineInputs.yourCurrentAge) || Number.isFinite(projection.engineInputs.age));
-        let solverBaseInputs = hasEngineInputs ? { ...projection.engineInputs } : { ...baseInputs };
+        let solverBaseInputs = { ...projection.engineInputs };
         // Ensure target income flows through via applyTargetToEngineInputs
         solverBaseInputs = applyTargetToEngineInputs(solverBaseInputs, resolvedTarget, {});
         const solverOptions = { swr: resolvedTarget.swr || DEFAULT_SWR };
@@ -320,6 +367,10 @@ export class ReversePlanner {
         );
 
         return {
+            inputHash: projection.inputHash,
+            policyVersion: projection.policyVersion,
+            projection,
+            warnings: projection.warnings || [],
             target: resolvedTarget,
             inputs: baseInputs,
             currentPath,

--- a/src/js/reverse-solver.js
+++ b/src/js/reverse-solver.js
@@ -767,6 +767,7 @@ export class ReverseRetirementSolver {
             salaryResult,
             retireAgeResult,
             superBalResult,
+            investmentBalResult,
             extraSavingsResult,
             netRentResult,
         ] = await Promise.all([
@@ -774,6 +775,7 @@ export class ReverseRetirementSolver {
             solveForSalary(this.simulator, baseInputs, target, opts),
             solveForRetirementAge(this.simulator, baseInputs, target, opts),
             solveForCurrentSuperBalance(this.simulator, baseInputs, target, opts),
+            solveForCurrentInvestmentBalance(this.simulator, baseInputs, target, opts),
             solveForExtraSavings(this.simulator, baseInputs, target, opts),
             solveForNetRent(this.simulator, baseInputs, target, opts),
         ]);
@@ -792,6 +794,7 @@ export class ReverseRetirementSolver {
             salaryResult,
             netRentResult,
             superBalResult,
+            investmentBalResult,
             estateResult,
         ];
 

--- a/src/js/reverse-ui.js
+++ b/src/js/reverse-ui.js
@@ -1070,6 +1070,7 @@ export class ReverseUI {
                 ['Household type', target.householdType === 'couple' ? 'Couple' : 'Single', 'Affects pension thresholds'],
                 ['Years to retirement', String(ytr), `Current age to age ${RET_AGE}`],
                 ['Planning horizon', `${LIFESPAN - (inp.yourCurrentAge || RET_AGE)} years in retirement`, `Age ${RET_AGE} to ${LIFESPAN}`],
+                ['Projection input hash', this.lastResult.inputHash || 'Unavailable', 'Shared by current path, solvers, screen results and this PDF'],
             ],
             {
                 columnStyles: {
@@ -1172,6 +1173,9 @@ export class ReverseUI {
 
         // Assumptions
         const assumptions = generateAssumptionsText(target, result.inputs);
+        if (result.inputHash) {
+            assumptions.push(`Projection input hash: ${result.inputHash}`);
+        }
         const assumEl = el('rp-assumptions-list');
         if (assumEl) {
             assumEl.innerHTML = assumptions.map(a => `<li>${a}</li>`).join('');
@@ -1544,7 +1548,7 @@ export class ReverseUI {
         const section = el('rp-deep-analysis-section');
         if (!section) return;
 
-        const inputs = result.inputs || {};
+        const inputs = result.projection?.engineInputs || result.inputs || {};
         const target = result.target || {};
 
         show('rp-deep-analysis-section');

--- a/src/js/reverse-ui.js
+++ b/src/js/reverse-ui.js
@@ -37,6 +37,7 @@ import {
     calculateSalaryReductionTolerance,
     calculateOptimalOverseasAge,
 } from './reverse-deep-analysis.js';
+import { ReverseScenarioEngine } from './calculation/reverse-scenario-engine.js';
 
 const STORAGE_KEY = 'rc_forward_scenario';
 
@@ -48,6 +49,14 @@ const CURRENCY_FORMAT = new Intl.NumberFormat('en-AU', {
 });
 
 function fmt(v) { return CURRENCY_FORMAT.format(Math.round(v)); }
+function escapeHtml(value) {
+    return String(value ?? '')
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#039;');
+}
 function el(id) { return document.getElementById(id); }
 function safeText(id, text) {
     const elem = el(id);
@@ -73,6 +82,8 @@ function show(id) {
 export class ReverseUI {
     constructor() {
         this.planner = new ReversePlanner();
+        this.scenarioEngine = new ReverseScenarioEngine(ENHANCED_CONFIG);
+        this.scenarioBuilderResults = null;
         this.lastResult = null;
         this.isCalculating = false;
         this.baseline = null;
@@ -104,6 +115,10 @@ export class ReverseUI {
         const calcBtn = el('rp-calculate-btn');
         if (calcBtn) {
             calcBtn.addEventListener('click', () => this.handleCalculate());
+        }
+        const scenarioBtn = el('rsb-calculate');
+        if (scenarioBtn) {
+            scenarioBtn.addEventListener('click', () => this.handleScenarioBuilder());
         }
 
         // Manual fallback toggle
@@ -421,6 +436,123 @@ export class ReverseUI {
         return { inputs, target };
     }
 
+    collectScenarioBuilderInputs() {
+        const number = (id, fallback = 0) => {
+            const value = Number(el(id)?.value);
+            return Number.isFinite(value) ? value : fallback;
+        };
+        const householdType = el('rsb-household')?.value || 'couple';
+        const currentAge = number('rsb-age', 49);
+        const partnerAge = householdType === 'couple' ? number('rsb-partner-age', 47) : 0;
+        const retirementAge = number('rsb-retirement-age', 67);
+        const lifespan = number('rsb-lifespan', 92);
+        const targetAnnualIncomeToday = number('rsb-target-income', 84000);
+        const confidenceTarget = number('rsb-confidence', 80) / 100;
+        const homeStatus = el('rsb-home-status')?.value || 'own_home';
+        const baseEngineInputs = this.forwardProjection?.engineInputs
+            || this.lastResult?.projection?.engineInputs
+            || {};
+        const projectionInput = {
+            ...baseEngineInputs,
+            householdType,
+            isCouple: householdType === 'couple',
+            isSingleCalculation: householdType !== 'couple',
+            currentAge,
+            yourCurrentAge: currentAge,
+            partnerAge,
+            partnerCurrentAge: partnerAge,
+            retirementAge,
+            partnerRetirementAge: retirementAge,
+            lifespan,
+            yourLifespan: lifespan,
+            partnerLifespan: householdType === 'couple' ? lifespan : 0,
+            targetAnnualIncomeToday,
+            asfaComfortable: targetAnnualIncomeToday,
+            primaryRentMonthly: number('rsb-primary-rent', 0),
+        };
+        const target = {
+            currentAge,
+            retirementAge,
+            lifespan,
+            targetAnnualIncomeToday,
+            successProbabilityTarget: confidenceTarget,
+            confidenceTarget,
+            minimumEstateToday: 0,
+            includeAgePension: el('rsb-include-pension')?.checked !== false,
+            householdType,
+        };
+        const selected = {
+            includeSuper: el('rsb-include-super')?.checked !== false,
+            includeAgePension: el('rsb-include-pension')?.checked !== false,
+            includeNonSuperInvestments: el('rsb-include-non-super')?.checked !== false,
+            homeStatus,
+            includeInvestmentProperty: Boolean(el('rsb-include-property')?.checked),
+            sellInvestmentPropertyAtRetirement: Boolean(el('rsb-sell-property')?.checked),
+            includeDownsizing: Boolean(el('rsb-include-downsizing')?.checked),
+            includeAgedCare: Boolean(el('rsb-include-aged-care')?.checked),
+            includeOverseasRetirement: Boolean(el('rsb-include-overseas')?.checked),
+        };
+        return { projectionInput, target, selected };
+    }
+
+    async handleScenarioBuilder() {
+        const button = el('rsb-calculate');
+        const status = el('rsb-status');
+        if (button) button.disabled = true;
+        if (status) status.textContent = 'Solving scenario comparison paths…';
+        try {
+            const { projectionInput, target, selected } = this.collectScenarioBuilderInputs();
+            const projection = this.planner.projectionService.computeProjection(
+                projectionInput,
+                { sourceCalculator: 'reverse-scenario' }
+            );
+            const results = await this.scenarioEngine.compareScenarios(
+                projection.engineInputs,
+                target,
+                selected,
+                { swr: 0.04 }
+            );
+            this.scenarioBuilderResults = {
+                inputHash: projection.inputHash,
+                policyVersion: projection.policyVersion,
+                target,
+                selected,
+                results,
+            };
+            this.renderScenarioBuilderResults(this.scenarioBuilderResults);
+            if (status) {
+                status.textContent = 'Scenario comparison complete · input hash ' + projection.inputHash;
+            }
+        } catch (error) {
+            console.error('Scenario builder error:', error);
+            if (status) status.textContent = error.message || 'Scenario comparison could not be completed.';
+        } finally {
+            if (button) button.disabled = false;
+        }
+    }
+
+    renderScenarioBuilderResults(scenarioSet) {
+        const tbody = el('rsb-results-body');
+        if (!tbody) return;
+        const value = (amount, suffix = '') => amount == null ? '—' : fmt(amount) + suffix;
+        tbody.innerHTML = scenarioSet.results.map((scenario) => `
+            <tr>
+              <td><strong>${escapeHtml(scenario.scenarioName)}</strong></td>
+              <td>${value(scenario.requiredCurrentSuper)}</td>
+              <td>${value(scenario.requiredCurrentNonSuperInvestments)}</td>
+              <td>${value(scenario.requiredCurrentGrossSalary, '/yr')}</td>
+              <td>${value(scenario.requiredMonthlySurplus, '/mo')}</td>
+              <td>${value(scenario.requiredAnnualSalarySacrifice, '/yr')}</td>
+              <td>${value(scenario.requiredPropertyEquityOrRentalIncome, '/wk')}</td>
+              <td>${value(scenario.expectedAgePensionContribution, '/yr')}</td>
+              <td>${value(scenario.expectedAssetsAtRetirement)}</td>
+              <td>${value(scenario.expectedEstateAtLifespan)}</td>
+              <td>${scenario.warnings.map((warning) => escapeHtml(warning)).join('<br>')}</td>
+            </tr>
+        `).join('');
+        show('rsb-results');
+    }
+
     /**
      * Build inputs from manual fallback form fields.
      */
@@ -729,6 +861,38 @@ export class ReverseUI {
                 `Your current plan is projected to meet your retirement goal.`,
                 `Continue current savings and review annually to maintain this position.`,
             ], [209, 250, 229], [5, 150, 105]);
+        }
+
+        heading('Scenario Builder: What do we need today?', 11);
+        if (this.scenarioBuilderResults?.results?.length) {
+            const scenarioValue = (amount, suffix = '') => amount == null ? '—' : cur(amount) + suffix;
+            bullet('Scenario input hash', this.scenarioBuilderResults.inputHash || 'Unavailable');
+            bullet('Target retirement income', cur(this.scenarioBuilderResults.target.targetAnnualIncomeToday) + '/year');
+            bullet('Confidence target', pct(this.scenarioBuilderResults.target.confidenceTarget || 0));
+            autoTable(
+                ['Scenario', 'Super now', 'Non-super now', 'Gross salary', 'Monthly surplus', 'Salary sacrifice', 'Age Pension'],
+                this.scenarioBuilderResults.results.map((scenario) => [
+                    scenario.scenarioName,
+                    scenarioValue(scenario.requiredCurrentSuper),
+                    scenarioValue(scenario.requiredCurrentNonSuperInvestments),
+                    scenarioValue(scenario.requiredCurrentGrossSalary, '/yr'),
+                    scenarioValue(scenario.requiredMonthlySurplus, '/mo'),
+                    scenarioValue(scenario.requiredAnnualSalarySacrifice, '/yr'),
+                    scenarioValue(scenario.expectedAgePensionContribution, '/yr'),
+                ]),
+                { styles: { fontSize: 6.5 } }
+            );
+            const scenarioWarnings = Array.from(new Set(
+                this.scenarioBuilderResults.results.flatMap((scenario) => scenario.warnings || [])
+            ));
+            if (scenarioWarnings.length) {
+                infoBox(scenarioWarnings, [255, 251, 235], [180, 83, 9]);
+            }
+        } else {
+            infoBox([
+                'Scenario Builder was not run for this report.',
+                'Run the top Scenario Builder section to include salary, asset and monthly-surplus comparisons.',
+            ], [248, 250, 252], [71, 85, 105]);
         }
 
         // ── PAGE 1/2: CURRENT FINANCIAL SNAPSHOT ────────────────────────────

--- a/src/js/simulator.js
+++ b/src/js/simulator.js
@@ -75,6 +75,19 @@ export function stochasticRate(centralRate, isStochastic = true, floor = 0, sigm
     return Math.max(floor, centralRate + z * effectiveSigma);
 }
 
+export function stochasticSigmaForRate(centralRate, rateType = 'generic') {
+    const settings = {
+        inflation: { minimum: 0.005, multiplier: 0.4 },
+        healthcare: { minimum: 0.01, multiplier: 0.4 },
+        salary: { minimum: 0.005, multiplier: 0.3 },
+        super: { minimum: 0.03, multiplier: 0.6 },
+        savings: { minimum: 0.005, multiplier: 0.3 },
+        generic: { minimum: 0.01, multiplier: 0.5 },
+    };
+    const setting = settings[rateType] || settings.generic;
+    return Math.max(setting.minimum, Math.abs(centralRate || 0) * setting.multiplier);
+}
+
 export class RetirementSimulator {
     constructor(config) {
         // Merge original config with enhanced financial config
@@ -1362,9 +1375,24 @@ export class RetirementSimulator {
         // etc.).  Quantities that are re-calculated each year inside the loop (savings
         // return, super return, retirement inflation) already use per-year draws via
         // stochasticRate() and are unaffected by these run-level draws.
-        const runInflationRate      = stochasticRate(inputs.inflation,            useRandomReturns, 0.001);
-        const runHealthcareInflRate = stochasticRate(inputs.healthcareInflation ?? 0.065, useRandomReturns, 0.01);
-        const runSalaryGrowthRate   = stochasticRate(inputs.salaryGrowthRate ?? 0.02,     useRandomReturns, 0);
+        const runInflationRate = stochasticRate(
+            effectiveInputs.inflation,
+            useRandomReturns,
+            0.001,
+            stochasticSigmaForRate(effectiveInputs.inflation, 'inflation')
+        );
+        const runHealthcareInflRate = stochasticRate(
+            effectiveInputs.healthcareInflation ?? 0.065,
+            useRandomReturns,
+            0.01,
+            stochasticSigmaForRate(effectiveInputs.healthcareInflation ?? 0.065, 'healthcare')
+        );
+        const runSalaryGrowthRate = stochasticRate(
+            effectiveInputs.salaryGrowthRate ?? 0.02,
+            useRandomReturns,
+            0,
+            stochasticSigmaForRate(effectiveInputs.salaryGrowthRate ?? 0.02, 'salary')
+        );
         // NOTE: property growth is NOT drawn as a single per-run rate here.
         // Instead, calculateEnhancedPropertyReturn() is called each year inside the
         // accumulation and retirement loops so each year can experience a different
@@ -1568,7 +1596,12 @@ export class RetirementSimulator {
             // stochasticRate() centred on the user's input (median).  The cumulative
             // factor replaces Math.pow(1 + runInflationRate, year) throughout, giving
             // year-to-year variation for all inflation-dependent costs.
-            const accumYearInflationRate = stochasticRate(inputs.inflation, useRandomReturns, 0.001);
+            const accumYearInflationRate = stochasticRate(
+                inputs.inflation,
+                useRandomReturns,
+                0.001,
+                stochasticSigmaForRate(inputs.inflation, 'inflation')
+            );
             accumCumulativeInflationFactor *= (1 + accumYearInflationRate);
 
             // Dynamic allocation
@@ -1675,10 +1708,20 @@ export class RetirementSimulator {
                 }
             }
 
-            // Apply returns — super and savings use stochastic rates (user-entered rate
-            // treated as median; each year perturbed uniformly by ±4pp)
-            const yearSuperReturn = stochasticRate(inputs.superReturn, useRandomReturns, 0);
-            const yearSavingsReturn = stochasticRate(inputs.savingsReturn, useRandomReturns, 0);
+            // Apply type-specific stochastic rates consistent with the shared engines.
+            // Super can experience negative years; bank savings retain a zero floor.
+            const yearSuperReturn = stochasticRate(
+                inputs.superReturn,
+                useRandomReturns,
+                -0.30,
+                stochasticSigmaForRate(inputs.superReturn, 'super')
+            );
+            const yearSavingsReturn = stochasticRate(
+                inputs.savingsReturn,
+                useRandomReturns,
+                0,
+                stochasticSigmaForRate(inputs.savingsReturn, 'savings')
+            );
             const yourSuperEarningsThisYear = yourSuperBalance * yearSuperReturn;
             const partnerSuperEarningsThisYear = partnerSuperBalance * yearSuperReturn;
             const superEarningsThisYear = yourSuperEarningsThisYear + partnerSuperEarningsThisYear;
@@ -2145,9 +2188,13 @@ export class RetirementSimulator {
             // ── Step A: draw this year's stochastic rate ─────────────────────────
             // yearInflationRate MUST be declared before any calculation that uses it.
             // It drives healthcare costs, spending targets, and the cumulative factor.
-            // Uniform draw in [median − 4pp, median + 4pp], floored at 0.5%.
-            // Every year draws a fresh rate — never a fixed linear compound of the median.
-            const yearInflationRate = stochasticRate(inputs.inflation, useRandomReturns, 0.005);
+            // Every year draws a fresh normal rate around the user-entered median.
+            const yearInflationRate = stochasticRate(
+                inputs.inflation,
+                useRandomReturns,
+                0.005,
+                stochasticSigmaForRate(inputs.inflation, 'inflation')
+            );
 
             // ── Step B: healthcare costs ─────────────────────────────────────────
             // MC mode: healthcare cost = baseCost × cumulativeInflationFactor

--- a/src/js/simulator.js
+++ b/src/js/simulator.js
@@ -39,26 +39,16 @@ const resolveScenarioMonteCarloRuns = (inputs = {}) =>
     Math.max(100, Math.min(20000, Math.round(Number(inputs.numRuns) || 1000)));
 
 /**
- * Generate a stochastic annual rate by applying a bounded symmetric variation
- * to the user-supplied central (median) estimate.  Each call draws a uniform
- * perturbation from [-0.04, +0.04] (±4 pp), so the distribution is centred on
- * the user's input.  This means every year experiences a different rate drawn
- * from a distribution whose median equals the user's input — the value is never
- * applied as a fixed linear compound across all years.
- *
- * Why ±4 pp?  AU macro data (RBA/ABS 2002-2024):
- *   CPI std dev ≈ 1.8 pp  →  ±4 pp covers roughly ±2.2 σ  (≈97% of history)
- *   Super returns std dev ≈ 8 pp  →  ±4 pp is a conservative ±0.5 σ
- * The same range is used for all rates for simplicity; the floor parameter
- * prevents rates from going below a caller-specified minimum.
- *
- * Note: an asymmetric range such as [-0.045, +0.035] shifts the median of
- * the distribution by -0.5 pp relative to the user input, biasing all
- * projections downward — which is why this implementation uses a symmetric range.
+ * Generate a stochastic annual rate around the user-supplied central estimate.
+ * The implementation uses a Box-Muller normal draw. Callers may supply sigma;
+ * otherwise volatility defaults to max(1 percentage point, 50% of the absolute
+ * central rate). The result has a lower floor but intentionally has no hard
+ * upper bound.
  *
  * @param {number}  centralRate         - Median rate as decimal (e.g. 0.026 for 2.6%)
  * @param {boolean} [isStochastic=true] - When false (deterministic mode), returns centralRate unchanged
  * @param {number}  [floor=0]           - Hard floor for result (e.g. 0.001 = 0.1% minimum)
+ * @param {number|null} [sigma=null]     - Optional standard deviation in decimal rate units
  * @returns {number} Perturbed rate in decimal form, ≥ floor (or centralRate when deterministic)
  *
  * Backward-compat: two-arg legacy call stochasticRate(rate, floor) is detected when

--- a/src/js/simulator.js
+++ b/src/js/simulator.js
@@ -1888,8 +1888,10 @@ export class RetirementSimulator {
             const annualDetailedExpenses = inputs.useDetailedExpenseInputs
                 ? (((inputs.currentMonthlyHousingCosts || 0) + (inputs.currentMonthlyLivingCosts || 0)) * 12) + (inputs.currentHealthcareCosts || 0)
                 : null;
-            const annualCashSavings = inputs.useDetailedExpenseInputs
-                ? Math.max(0, yearlyPostTaxIncome - annualDetailedExpenses)
+            const annualCashSavings = Number.isFinite(inputs.annualCashSavingsContribution)
+                ? Math.max(0, inputs.annualCashSavingsContribution)
+                : inputs.useDetailedExpenseInputs
+                    ? Math.max(0, yearlyPostTaxIncome - annualDetailedExpenses)
                 : Math.max(0, yearlyPostTaxIncome * (inputs.percentIncomeSaved || 0));
             accumulatedSavingsBalance += annualCashSavings;
 

--- a/src/reverse.html
+++ b/src/reverse.html
@@ -62,6 +62,49 @@
   <!-- ───── SINGLE-COLUMN CONTENT ───── -->
   <div style="max-width:800px;margin:0 auto;padding:8px 28px 140px;display:flex;flex-direction:column;gap:var(--section-gap)">
 
+    <section class="section open" id="rsb-section" data-section="scenario-builder">
+      <button class="section-head" type="button">
+        <span class="section-num">★</span>
+        <span class="section-title">
+          <h3>Scenario Builder: What do we need today?</h3>
+          <small>Start from ages and retirement income, then compare funding paths</small>
+        </span>
+        <span class="section-meta"></span>
+        <svg class="section-chev" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
+      </button>
+      <div class="section-body">
+        <div class="fields three">
+          <div class="field"><label class="field-label" for="rsb-household"><span>Household</span></label><div class="field-input"><select id="rsb-household"><option value="single">Single</option><option value="couple" selected>Couple</option></select></div></div>
+          <div class="field"><label class="field-label" for="rsb-age"><span>Your current age</span></label><div class="field-input"><input id="rsb-age" type="number" min="18" max="80" value="49" /></div></div>
+          <div class="field"><label class="field-label" for="rsb-partner-age"><span>Partner age</span></label><div class="field-input"><input id="rsb-partner-age" type="number" min="18" max="80" value="47" /></div></div>
+          <div class="field"><label class="field-label" for="rsb-retirement-age"><span>Retirement age</span></label><div class="field-input"><input id="rsb-retirement-age" type="number" min="40" max="85" value="67" /></div></div>
+          <div class="field"><label class="field-label" for="rsb-target-income"><span>Desired after-tax retirement income</span><span class="hint">today's $/yr</span></label><div class="field-input has-prefix"><span class="prefix">$</span><input id="rsb-target-income" type="number" min="0" value="84000" /></div></div>
+          <div class="field"><label class="field-label" for="rsb-confidence"><span>Confidence target</span></label><div class="field-input"><select id="rsb-confidence"><option value="70">70%</option><option value="80" selected>80%</option><option value="90">90%</option></select></div></div>
+          <div class="field"><label class="field-label" for="rsb-lifespan"><span>Planning lifespan</span></label><div class="field-input"><input id="rsb-lifespan" type="number" min="70" max="120" value="92" /></div></div>
+          <div class="field"><label class="field-label" for="rsb-home-status"><span>Home status</span></label><div class="field-input"><select id="rsb-home-status"><option value="own_home">Own home</option><option value="own_home_with_mortgage">Own home with mortgage</option><option value="renting">Renting</option><option value="no_home">No home</option></select></div></div>
+          <div class="field"><label class="field-label" for="rsb-primary-rent"><span>Monthly rent</span></label><div class="field-input has-prefix"><span class="prefix">$</span><input id="rsb-primary-rent" type="number" min="0" value="0" /></div></div>
+        </div>
+        <div class="fields three" style="margin-top:12px">
+          <label class="toggle"><input id="rsb-include-super" type="checkbox" checked /><span class="track"></span><span class="label">Include super</span></label>
+          <label class="toggle"><input id="rsb-include-pension" type="checkbox" checked /><span class="track"></span><span class="label">Include Age Pension</span></label>
+          <label class="toggle"><input id="rsb-include-non-super" type="checkbox" checked /><span class="track"></span><span class="label">Include non-super investments</span></label>
+          <label class="toggle"><input id="rsb-include-property" type="checkbox" /><span class="track"></span><span class="label">Include investment property</span></label>
+          <label class="toggle"><input id="rsb-sell-property" type="checkbox" /><span class="track"></span><span class="label">Sell property at retirement</span></label>
+          <label class="toggle"><input id="rsb-include-downsizing" type="checkbox" /><span class="track"></span><span class="label">Include downsizing</span></label>
+          <label class="toggle"><input id="rsb-include-aged-care" type="checkbox" /><span class="track"></span><span class="label">Include aged care</span></label>
+          <label class="toggle"><input id="rsb-include-overseas" type="checkbox" /><span class="track"></span><span class="label">Include overseas retirement</span></label>
+        </div>
+        <button id="rsb-calculate" class="iconbtn primary" style="margin-top:14px">Compare what we need today</button>
+        <p id="rsb-status" style="font-size:12px;color:var(--ink-3);margin:8px 0 0">Deterministic lever solves are shown first. Confidence targets require Monte Carlo validation.</p>
+        <div id="rsb-results" class="hidden" style="margin-top:16px;overflow-x:auto">
+          <table class="year-table" style="min-width:1500px;font-size:11.5px">
+            <thead><tr><th>Scenario</th><th>Current super needed</th><th>Non-super needed</th><th>Gross salary needed</th><th>Monthly surplus</th><th>Salary sacrifice</th><th>Property / rent</th><th>Age Pension</th><th>Assets at retirement</th><th>Estate</th><th>Warnings</th></tr></thead>
+            <tbody id="rsb-results-body"></tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
     <!-- ════════════════════════════════════════
          SECTION 1: YOUR CURRENT POSITION
          ════════════════════════════════════════ -->

--- a/tests/integration/reverse-integration.test.js
+++ b/tests/integration/reverse-integration.test.js
@@ -22,15 +22,6 @@ import { applyTargetToEngineInputs, evaluateEngineGoal } from '../../src/js/reve
 // Shared test fixtures
 // ---------------------------------------------------------------------------
 
-// Pin Math.random to median so stochasticRate() in the simulator returns
-// central values and bisection results are reproducible across test runs.
-beforeAll(() => {
-    jest.spyOn(Math, 'random').mockReturnValue(0.5);
-});
-afterAll(() => {
-    jest.restoreAllMocks();
-});
-
 const simulator = new RetirementSimulator(ENHANCED_CONFIG);
 
 const BASE_INPUTS = {

--- a/tests/unit/advanced-classic-v2-normalized-parity.test.js
+++ b/tests/unit/advanced-classic-v2-normalized-parity.test.js
@@ -5,6 +5,7 @@ import { ENHANCED_CONFIG } from '../../src/js/config.js';
 import { populateFormFromData } from '../../src/js/utils.js';
 import templateData from '../../src/retirement_template.json';
 import { buildEngineInputs } from '../../src/js/advanced-v2.js';
+import RetirementSimulator from '../../src/js/simulator.js';
 
 const advancedHtml = fs.readFileSync(
     path.join(__dirname, '../../src/advanced.html'),
@@ -151,5 +152,48 @@ describe('advanced classic vs advanced-v2 normalized input parity', () => {
         const unexpected = diffs.filter((diff) => !diff.reason);
 
         expect(unexpected).toEqual([]);
+    });
+
+    test('shared projection service preserves the classic deterministic result for legacy inputs', () => {
+        const inputs = buildClassicInputsFromTemplate();
+        const simulator = new RetirementSimulator(ENHANCED_CONFIG);
+        const legacy = simulator.simulateRetirement(inputs, false);
+        const app = Object.create(RetirementCalculatorApp.prototype);
+        app.config = ENHANCED_CONFIG;
+        app.simulator = new RetirementSimulator(ENHANCED_CONFIG);
+        app.projectionService = app.createProjectionService();
+
+        const projection = app.projectionService.computeProjection(inputs, {
+            sourceCalculator: 'advanced',
+        });
+
+        expect(projection.simulation.finalBalance).toBeCloseTo(legacy.finalBalance, 8);
+        expect(projection.simulation.accumulatedSuperBalance).toBeCloseTo(
+            legacy.accumulatedSuperBalance,
+            8
+        );
+    });
+
+    test('classic detailed housing spending does not subtract mortgage twice', () => {
+        const inputs = {
+            ...buildClassicInputsFromTemplate(),
+            useDetailedExpenseInputs: true,
+            currentMonthlyHousingCosts: 5000,
+            currentMonthlyLivingCosts: 3000,
+            currentHealthcareCosts: 0,
+            monthlyMortgagePayment: 3200,
+            monthlyStockContribution: 0,
+        };
+        const app = Object.create(RetirementCalculatorApp.prototype);
+        app.config = ENHANCED_CONFIG;
+        app.simulator = new RetirementSimulator(ENHANCED_CONFIG);
+        app.projectionService = app.createProjectionService();
+
+        const projection = app.projectionService.computeProjection(inputs, {
+            sourceCalculator: 'advanced',
+        });
+
+        expect(projection.derivedCashflow.annualMortgageRepayments).toBe(0);
+        expect(projection.derivedCashflow.currentAnnualSpending).toBe(96000);
     });
 });

--- a/tests/unit/advanced-v2-engine-adapter.test.js
+++ b/tests/unit/advanced-v2-engine-adapter.test.js
@@ -3,6 +3,7 @@ import {
     adaptEngineOutput,
     applyHouseholdVisibility,
     buildEngineInputs,
+    computeBaseState,
     buildInputSignature,
     calculateRichTargetAmount,
     calculateTargetBuilderTotal,
@@ -829,6 +830,47 @@ describe('advanced-v2 secondary analysis stale handling', () => {
         expect(fullRunSource).not.toContain('runStressAnalysis(');
         expect(fullRunSource).not.toContain('runOverseasAnalysis(');
         expect(fullRunSource).not.toContain('runRetirementAgeAnalysis(');
+    });
+});
+
+describe('advanced-v2 canonical cashflow projection', () => {
+    test('carries the full $20k income / $7k spend surplus into accumulation', () => {
+        const input = buildRedesignInputs({
+            useDetailedCashflow: true,
+            currentMonthlyIncome: 20000,
+            currentMonthlyLivingCosts: 7000,
+            surplusAllocationMode: 'cash',
+            monthlyStockContrib: 0,
+            healthcareCost: 0,
+            primaryResidenceType: 'own_outright',
+            homeValue: 850000,
+            mortgage: 0,
+        });
+
+        const state = computeBaseState(input);
+        const openingLiquidAssets = input.cash + input.stocks;
+        const firstAccumulationYear = state.simulation.accumulationHistory[1];
+
+        expect(state.projection.derivedCashflow.monthlySurplus).toBe(13000);
+        expect(state.engineInputs.annualCashSavingsContribution).toBe(156000);
+        expect(firstAccumulationYear.nonSuperLiquidAssets - openingLiquidAssets).toBeGreaterThanOrEqual(156000);
+    });
+
+    test('preserves legacy explicit-contribution inputs when detailed cashflow is off', () => {
+        const input = buildRedesignInputs({
+            useDetailedCashflow: false,
+            currentMonthlyIncome: 20000,
+            currentMonthlyLivingCosts: 7000,
+            monthlyStockContrib: 500,
+        });
+
+        const state = computeBaseState(input);
+
+        expect(state.engineInputs.annualCashSavingsContribution).toBeUndefined();
+        expect(state.engineInputs.monthlyStockContribution).toBe(500);
+        expect(state.projection.warnings).toContain(
+            'Current household spending is missing, so no implicit surplus was allocated.'
+        );
     });
 });
 

--- a/tests/unit/app-validation.test.js
+++ b/tests/unit/app-validation.test.js
@@ -76,6 +76,18 @@ describe('lifespan validation', () => {
 
         expect(errors).not.toContain('Asset allocation sums to 0% — must equal 100%.');
     });
+
+    test('rejects detailed cashflow mode when all current expenses are zero', () => {
+        const app = Object.create(RetirementCalculatorApp.prototype);
+        const errors = app.validateInputs(buildInputs({
+            useDetailedExpenseInputs: true,
+            currentHealthcareCosts: 0,
+        }));
+
+        expect(errors).toContain(
+            'Enter current household expenses before enabling explicit monthly expense inputs.'
+        );
+    });
 });
 
 describe('dynamic allocation collection', () => {

--- a/tests/unit/calculation-consolidation.test.js
+++ b/tests/unit/calculation-consolidation.test.js
@@ -1,0 +1,118 @@
+import { normaliseCanonicalInput } from '../../src/js/calculation/canonical-input-schema.js';
+import { deriveHouseholdCashflow } from '../../src/js/calculation/household-cashflow-engine.js';
+import { ProjectionService } from '../../src/js/calculation/projection-service.js';
+import { adaptAdvancedV2Input } from '../../src/js/calculation/input-adapters/advanced-v2-adapter.js';
+
+describe('calculator consolidation foundations', () => {
+    test('allocates the full $20k income / $7k spend surplus instead of discarding it', () => {
+        const canonicalInput = normaliseCanonicalInput({
+            cashflow: {
+                currentMonthlyIncome: 20000,
+                currentMonthlyTotalSpend: 7000,
+                surplusAllocationMode: 'cash',
+            },
+        });
+
+        const result = deriveHouseholdCashflow(canonicalInput);
+
+        expect(result.monthlySurplus).toBe(13000);
+        expect(result.allocations.cash).toBe(156000);
+        expect(result.allocatedSurplus).toBe(156000);
+        expect(result.unallocatedSurplus).toBe(0);
+        expect(result.warnings).toEqual([]);
+    });
+
+    test('caches one deterministic run per input hash and invalidates changed input', () => {
+        const simulator = { simulateRetirement: jest.fn(() => ({ yearlyData: [] })) };
+        const service = new ProjectionService({
+            simulator,
+            adapter: normaliseCanonicalInput,
+            engineInputBuilder: (_raw, { derivedCashflow }) => ({ derivedCashflow }),
+        });
+        const input = {
+            household: { currentAge: 49, retirementAge: 67 },
+            cashflow: { currentMonthlyIncome: 20000, currentMonthlyTotalSpend: 7000 },
+        };
+
+        const first = service.computeProjection(input);
+        const second = service.computeProjection({ ...input });
+        const changed = service.computeProjection({
+            ...input,
+            cashflow: { ...input.cashflow, currentMonthlyTotalSpend: 7100 },
+        });
+
+        expect(second).toBe(first);
+        expect(changed.inputHash).not.toBe(first.inputHash);
+        expect(simulator.simulateRetirement).toHaveBeenCalledTimes(2);
+    });
+
+    test('does not invent surplus when detailed spending is missing', () => {
+        const canonicalInput = normaliseCanonicalInput({
+            income: { annualSalary: 120000 },
+            cashflow: { explicitMonthlyInvestmentContribution: 500 },
+        });
+
+        const result = deriveHouseholdCashflow(canonicalInput);
+
+        expect(result.annualSurplus).toBeNull();
+        expect(result.monthlySurplus).toBeNull();
+        expect(result.allocatedSurplus).toBe(0);
+        expect(result.warnings).toContain(
+            'Current household spending is missing, so no implicit surplus was allocated.'
+        );
+    });
+
+    test('caps a custom split instead of creating money', () => {
+        const canonicalInput = normaliseCanonicalInput({
+            cashflow: {
+                currentMonthlyIncome: 10000,
+                currentMonthlyTotalSpend: 9000,
+                surplusAllocationMode: 'custom_split',
+                surplusToCashMonthly: 1000,
+                surplusToStocksMonthly: 1000,
+            },
+        });
+
+        const result = deriveHouseholdCashflow(canonicalInput);
+
+        expect(result.allocatedSurplus).toBe(12000);
+        expect(result.allocations.cash).toBe(6000);
+        expect(result.allocations.stocks).toBe(6000);
+        expect(result.unallocatedSurplus).toBe(0);
+        expect(result.warnings).toContain(
+            'Custom surplus allocations were capped at the available household surplus.'
+        );
+    });
+
+    test('advanced-v2 adapter converts package-inclusive salary before cashflow tax', () => {
+        const canonicalInput = adaptAdvancedV2Input({
+            household: 'single',
+            salary: 112000,
+            salaryIncomeMode: 'package_including_super',
+            employerRate: 12,
+            applyMaxContributionBase: true,
+        });
+
+        expect(canonicalInput.income.annualSalary).toBeCloseTo(100000, 2);
+        expect(canonicalInput.income.employerSuperAnnual).toBeCloseTo(12000, 2);
+        expect(canonicalInput.income.salaryIncomeMode).toBe('gross');
+    });
+
+    test('super-first does not invent a partner concessional cap for a single household', () => {
+        const canonicalInput = normaliseCanonicalInput({
+            household: { householdType: 'single' },
+            income: { employerSuperAnnual: 12000 },
+            cashflow: {
+                currentMonthlyIncome: 15000,
+                currentMonthlyTotalSpend: 5000,
+                surplusAllocationMode: 'super_first',
+            },
+        });
+
+        const result = deriveHouseholdCashflow(canonicalInput);
+
+        expect(result.allocations.super).toBe(18000);
+        expect(result.superByMember).toEqual({ primary: 18000, partner: 0 });
+        expect(result.allocations.stocks).toBe(102000);
+    });
+});

--- a/tests/unit/calculation-consolidation.test.js
+++ b/tests/unit/calculation-consolidation.test.js
@@ -2,6 +2,7 @@ import { normaliseCanonicalInput } from '../../src/js/calculation/canonical-inpu
 import { deriveHouseholdCashflow } from '../../src/js/calculation/household-cashflow-engine.js';
 import { ProjectionService } from '../../src/js/calculation/projection-service.js';
 import { adaptAdvancedV2Input } from '../../src/js/calculation/input-adapters/advanced-v2-adapter.js';
+import { applyCanonicalCashflowToEngineInputs } from '../../src/js/calculation/canonical-engine-adapter.js';
 
 describe('calculator consolidation foundations', () => {
     test('allocates the full $20k income / $7k spend surplus instead of discarding it', () => {
@@ -62,6 +63,24 @@ describe('calculator consolidation foundations', () => {
         );
     });
 
+    test('does not invent surplus when detailed mode has zero spending', () => {
+        const canonicalInput = normaliseCanonicalInput({
+            income: { annualSalary: 120000 },
+            cashflow: {
+                hasDetailedExpenses: true,
+                currentMonthlyTotalSpend: 0,
+            },
+        });
+
+        const result = deriveHouseholdCashflow(canonicalInput);
+
+        expect(result.canAllocateSurplus).toBe(false);
+        expect(result.annualSurplus).toBeNull();
+        expect(result.warnings).toContain(
+            'Current household spending must be greater than zero before surplus can be allocated.'
+        );
+    });
+
     test('caps a custom split instead of creating money', () => {
         const canonicalInput = normaliseCanonicalInput({
             cashflow: {
@@ -114,5 +133,41 @@ describe('calculator consolidation foundations', () => {
         expect(result.allocations.super).toBe(18000);
         expect(result.superByMember).toEqual({ primary: 18000, partner: 0 });
         expect(result.allocations.stocks).toBe(102000);
+    });
+
+    test('engine bridge preserves legacy inputs unless usable detailed cashflow exists', () => {
+        const canonicalInput = normaliseCanonicalInput({
+            cashflow: { explicitMonthlyInvestmentContribution: 500 },
+        });
+        const derivedCashflow = deriveHouseholdCashflow(canonicalInput);
+        const base = {
+            monthlyStockContribution: 500,
+            useDetailedExpenseInputs: false,
+        };
+
+        expect(applyCanonicalCashflowToEngineInputs(base, canonicalInput, derivedCashflow)).toEqual({
+            ...base,
+            canonicalInputSchemaVersion: 'calculator-input-v1',
+        });
+    });
+
+    test('engine bridge carries the full derived cash surplus into an asset bucket', () => {
+        const canonicalInput = normaliseCanonicalInput({
+            cashflow: {
+                currentMonthlyIncome: 20000,
+                currentMonthlyTotalSpend: 7000,
+                surplusAllocationMode: 'cash',
+            },
+        });
+        const derivedCashflow = deriveHouseholdCashflow(canonicalInput);
+        const engineInputs = applyCanonicalCashflowToEngineInputs(
+            { monthlyStockContribution: 0 },
+            canonicalInput,
+            derivedCashflow
+        );
+
+        expect(engineInputs.annualCashSavingsContribution).toBe(156000);
+        expect(engineInputs.derivedAnnualSurplus).toBe(156000);
+        expect(engineInputs.monthlyStockContribution).toBe(0);
     });
 });

--- a/tests/unit/reverse-planner-regression.test.js
+++ b/tests/unit/reverse-planner-regression.test.js
@@ -1,6 +1,10 @@
 import { ReversePlanner, normaliseReversePlannerInputs } from '../../src/js/reverse-planner.js';
 
 describe('ReversePlanner regressions', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
     test('manual current path does not reference undefined gap variables', () => {
         const planner = new ReversePlanner();
         const inputs = normaliseReversePlannerInputs({
@@ -22,5 +26,35 @@ describe('ReversePlanner regressions', () => {
         };
 
         expect(() => planner.buildCurrentPath(inputs, target)).not.toThrow();
+    });
+
+    test('manual mode uses one projection hash for current path and solver inputs', async () => {
+        const planner = new ReversePlanner();
+        planner.solver.solveAllLevers = jest.fn().mockResolvedValue({ rankedLevers: [] });
+        const rawInputs = {
+            householdType: 'single',
+            currentAge: 50,
+            retirementAge: 67,
+            lifespan: 90,
+            annualSalary: 90000,
+            currentSuperBalance: 150000,
+            cashSavings: 20000,
+        };
+        const target = {
+            retirementAge: 67,
+            lifespan: 90,
+            targetAnnualIncomeToday: 50000,
+            successProbabilityTarget: 0.8,
+            includeAgePension: true,
+        };
+
+        const result = await planner.solve(rawInputs, target, { includeOverseas: false });
+        const solverInputs = planner.solver.solveAllLevers.mock.calls[0][0];
+
+        expect(result.inputHash).toBe(result.projection.inputHash);
+        expect(result.projection.sourceCalculator).toBe('reverse-manual');
+        expect(result.currentPath.simResult).toBe(result.projection.simulation);
+        expect(solverInputs.yourCurrentAge).toBe(result.projection.engineInputs.yourCurrentAge);
+        expect(solverInputs.yourCurrentSuper).toBe(result.projection.engineInputs.yourCurrentSuper);
     });
 });

--- a/tests/unit/reverse-planner-regression.test.js
+++ b/tests/unit/reverse-planner-regression.test.js
@@ -1,0 +1,26 @@
+import { ReversePlanner, normaliseReversePlannerInputs } from '../../src/js/reverse-planner.js';
+
+describe('ReversePlanner regressions', () => {
+    test('manual current path does not reference undefined gap variables', () => {
+        const planner = new ReversePlanner();
+        const inputs = normaliseReversePlannerInputs({
+            householdType: 'single',
+            currentAge: 50,
+            retirementAge: 67,
+            lifespan: 90,
+            annualSalary: 90000,
+            currentSuperBalance: 150000,
+            cashSavings: 20000,
+            targetAnnualIncomeToday: 50000,
+        });
+        const target = {
+            retirementAge: 67,
+            lifespan: 90,
+            targetAnnualIncomeToday: 50000,
+            confidenceTarget: 0,
+            includeAgePension: true,
+        };
+
+        expect(() => planner.buildCurrentPath(inputs, target)).not.toThrow();
+    });
+});

--- a/tests/unit/reverse-scenario-engine.test.js
+++ b/tests/unit/reverse-scenario-engine.test.js
@@ -1,0 +1,262 @@
+import { ENHANCED_CONFIG } from '../../src/js/config.js';
+import { ReverseScenarioEngine } from '../../src/js/calculation/reverse-scenario-engine.js';
+
+const baseInputs = {
+    yourCurrentAge: 49,
+    partnerCurrentAge: 47,
+    retirementAge: 67,
+    partnerRetirementAge: 67,
+    yourLifespan: 92,
+    partnerLifespan: 92,
+    isCouple: true,
+    isSingleCalculation: false,
+    yourSalary: 120000,
+    partnerSalary: 80000,
+    yourCurrentSuper: 200000,
+    partnerCurrentSuper: 100000,
+    currentSavings: 50000,
+    currentStocks: 25000,
+    monthlyStockContribution: 1000,
+    homeowner: true,
+    homeValue: 900000,
+    mortgageBalance: 200000,
+    monthlyMortgagePayment: 2500,
+    hasInvestmentProperty: true,
+    investmentPropertyValue: 600000,
+    investmentPropertyLoan: 300000,
+    weeklyRentalIncome: 600,
+    annualPropertyExpenses: 10000,
+    inflation: 0.026,
+    investmentReturn: 0.07,
+    superReturn: 0.075,
+};
+
+const target = {
+    currentAge: 49,
+    retirementAge: 67,
+    lifespan: 92,
+    targetAnnualIncomeToday: 84000,
+    successProbabilityTarget: 0.8,
+    includeAgePension: true,
+};
+
+describe('ReverseScenarioEngine', () => {
+    test('builds the required comparison set including the $84k couple paths', () => {
+        const engine = new ReverseScenarioEngine(ENHANCED_CONFIG, {
+            solver: { solveAllLevers: jest.fn() },
+        });
+
+        const scenarios = engine.buildScenarioDefinitions({});
+
+        expect(scenarios).toHaveLength(10);
+        expect(scenarios.map((scenario) => scenario.key)).toEqual(expect.arrayContaining([
+            'home_super_pension',
+            'home_super_private',
+            'renter_super_pension',
+            'non_super_only',
+            'property_retained',
+            'property_sold',
+            'salary_only',
+            'aged_care',
+            'stress',
+        ]));
+    });
+
+    test('Age Pension and renter toggles alter engine inputs and thresholds', () => {
+        const engine = new ReverseScenarioEngine(ENHANCED_CONFIG, {
+            solver: { solveAllLevers: jest.fn() },
+        });
+        const renter = engine.applyScenario(baseInputs, target, {
+            homeStatus: 'renting',
+            includeAgePension: false,
+            includeSuper: true,
+            includeNonSuperInvestments: true,
+            includeInvestmentProperty: false,
+        });
+
+        expect(renter.inputs.suppressAgePension).toBe(true);
+        expect(renter.inputs.homeowner).toBe(false);
+        expect(renter.inputs.homeValue).toBe(0);
+        expect(renter.inputs.pensionAssetThreshold).toBe(
+            ENHANCED_CONFIG.COUPLE_ASSET_THRESHOLD_NON_HOMEOWNER
+        );
+    });
+
+    test('super off zeroes super balances and contribution rates', () => {
+        const engine = new ReverseScenarioEngine(ENHANCED_CONFIG, {
+            solver: { solveAllLevers: jest.fn() },
+        });
+        const result = engine.applyScenario(baseInputs, target, {
+            homeStatus: 'own_home',
+            includeSuper: false,
+            includeAgePension: true,
+            includeNonSuperInvestments: true,
+            includeInvestmentProperty: false,
+        });
+
+        expect(result.inputs.yourCurrentSuper).toBe(0);
+        expect(result.inputs.partnerCurrentSuper).toBe(0);
+        expect(result.inputs.yourAdditionalSuperContribution).toBe(0);
+        expect(result.inputs.employerSuperContributionRate).toBe(0);
+    });
+
+    test('noCurrentAssets scenario zeroes super, savings, and investment property', () => {
+        const engine = new ReverseScenarioEngine(ENHANCED_CONFIG, {
+            solver: { solveAllLevers: jest.fn() },
+        });
+        const result = engine.applyScenario(baseInputs, target, {
+            homeStatus: 'own_home',
+            includeSuper: true,
+            includeAgePension: true,
+            includeNonSuperInvestments: true,
+            includeInvestmentProperty: false,
+            noCurrentAssets: true,
+        });
+
+        expect(result.inputs.yourCurrentSuper).toBe(0);
+        expect(result.inputs.partnerCurrentSuper).toBe(0);
+        expect(result.inputs.currentSavings).toBe(0);
+        expect(result.inputs.currentStocks).toBe(0);
+        expect(result.inputs.investmentPropertyValue).toBe(0);
+    });
+
+    test('investment property retained includes property values and no sale year', () => {
+        const engine = new ReverseScenarioEngine(ENHANCED_CONFIG, {
+            solver: { solveAllLevers: jest.fn() },
+        });
+        const result = engine.applyScenario(baseInputs, target, {
+            homeStatus: 'own_home',
+            includeSuper: true,
+            includeAgePension: true,
+            includeNonSuperInvestments: true,
+            includeInvestmentProperty: true,
+            sellInvestmentPropertyAtRetirement: false,
+        });
+
+        expect(result.inputs.hasInvestmentProperty).toBe(true);
+        expect(result.inputs.investmentPropertyValue).toBe(baseInputs.investmentPropertyValue);
+        expect(result.inputs.sellPropertyYears).toBeUndefined();
+    });
+
+    test('investment property sold at retirement sets sellPropertyYears', () => {
+        const engine = new ReverseScenarioEngine(ENHANCED_CONFIG, {
+            solver: { solveAllLevers: jest.fn() },
+        });
+        const result = engine.applyScenario(baseInputs, target, {
+            homeStatus: 'own_home',
+            includeSuper: true,
+            includeAgePension: true,
+            includeNonSuperInvestments: true,
+            includeInvestmentProperty: true,
+            sellInvestmentPropertyAtRetirement: true,
+        });
+
+        expect(result.inputs.hasInvestmentProperty).toBe(true);
+        expect(result.inputs.sellPropertyYears).toBeGreaterThan(0);
+    });
+
+    test('aged care on sets probability and annual cost defaults when not specified', () => {
+        const engine = new ReverseScenarioEngine(ENHANCED_CONFIG, {
+            solver: { solveAllLevers: jest.fn() },
+        });
+        const inputsWithoutAgedCare = { ...baseInputs, agedCareProbability: 0, agedCareAnnualCost: 0 };
+        const result = engine.applyScenario(inputsWithoutAgedCare, target, {
+            homeStatus: 'own_home',
+            includeSuper: true,
+            includeAgePension: true,
+            includeNonSuperInvestments: true,
+            includeAgedCare: true,
+        });
+
+        expect(result.inputs.agedCareProbability).toBeGreaterThan(0);
+        expect(result.inputs.agedCareAnnualCost).toBeGreaterThan(0);
+        expect(result.inputs.agedCareStartAge).toBeGreaterThan(0);
+    });
+
+    test('aged care off zeroes agedCareProbability', () => {
+        const engine = new ReverseScenarioEngine(ENHANCED_CONFIG, {
+            solver: { solveAllLevers: jest.fn() },
+        });
+        const result = engine.applyScenario(baseInputs, target, {
+            homeStatus: 'own_home',
+            includeSuper: true,
+            includeAgePension: true,
+            includeNonSuperInvestments: true,
+            includeAgedCare: false,
+        });
+
+        expect(result.inputs.agedCareProbability).toBe(0);
+        expect(result.inputs.agedCareAnnualCost).toBe(0);
+    });
+
+    test('stress scenario reduces returns and raises inflation', () => {
+        const engine = new ReverseScenarioEngine(ENHANCED_CONFIG, {
+            solver: { solveAllLevers: jest.fn() },
+        });
+        const normalResult = engine.applyScenario(baseInputs, target, {
+            homeStatus: 'own_home',
+            includeSuper: true,
+            includeAgePension: true,
+            includeNonSuperInvestments: true,
+            stress: false,
+        });
+        const stressResult = engine.applyScenario(baseInputs, target, {
+            homeStatus: 'own_home',
+            includeSuper: true,
+            includeAgePension: true,
+            includeNonSuperInvestments: true,
+            stress: true,
+        });
+
+        expect(stressResult.inputs.investmentReturn).toBeLessThan(normalResult.inputs.investmentReturn);
+        expect(stressResult.inputs.superReturn).toBeLessThan(normalResult.inputs.superReturn);
+        expect(stressResult.inputs.inflation).toBeGreaterThan(normalResult.inputs.inflation);
+    });
+
+    test('maps shared solver outputs into scenario-builder result columns', async () => {
+        const rankedLevers = [
+            { lever: 'superBalance', solved: 450000, feasible: true },
+            { lever: 'investmentBalance', solved: 300000, feasible: true },
+            { lever: 'salary', solved: 180000, feasible: true },
+            { lever: 'extraSavings', solved: 2500, feasible: true },
+            { lever: 'extraAnnualSuper', solved: 12000, feasible: true },
+            { lever: 'netRent', solved: 700, feasible: true },
+        ];
+        const solver = {
+            solveAllLevers: jest.fn().mockResolvedValue({
+                rankedLevers,
+                currentScore: {
+                    totalAssetsNominal: 1500000,
+                    estateToday: 250000,
+                    passesGoal: true,
+                },
+                currentResult: {
+                    yearlyData: [{ age: 67, pensionIncome: 20000 }],
+                },
+            }),
+        };
+        const engine = new ReverseScenarioEngine(ENHANCED_CONFIG, { solver });
+
+        const result = await engine.solveScenario(baseInputs, target, {
+            key: 'selected',
+            name: 'Selected plan',
+            homeStatus: 'own_home',
+            includeAgePension: true,
+            includeSuper: true,
+            includeNonSuperInvestments: true,
+            includeInvestmentProperty: true,
+        });
+
+        expect(result).toEqual(expect.objectContaining({
+            requiredCurrentSuper: 450000,
+            requiredCurrentNonSuperInvestments: 300000,
+            requiredCurrentGrossSalary: 180000,
+            requiredMonthlySurplus: 2500,
+            requiredAnnualSalarySacrifice: 12000,
+            requiredPropertyEquityOrRentalIncome: 700,
+            expectedAgePensionContribution: 20000,
+            expectedAssetsAtRetirement: 1500000,
+            expectedEstateAtLifespan: 250000,
+        }));
+    });
+});

--- a/tests/unit/reverse-solver-roundtrip.test.js
+++ b/tests/unit/reverse-solver-roundtrip.test.js
@@ -22,16 +22,6 @@ import { applyTargetToEngineInputs, evaluateEngineGoal } from '../../src/js/reve
 // Shared test fixtures
 // ---------------------------------------------------------------------------
 
-// The simulator uses stochasticRate() (Math.random) even in deterministic mode,
-// which makes bisection unreliable. Pin random to the median so rates equal their
-// central values and results are reproducible across test runs.
-beforeAll(() => {
-    jest.spyOn(Math, 'random').mockReturnValue(0.5);
-});
-afterAll(() => {
-    jest.restoreAllMocks();
-});
-
 const simulator = new RetirementSimulator(ENHANCED_CONFIG);
 
 // Fields the retirement simulator requires to avoid NaN in

--- a/tests/unit/reverse-solver.test.js
+++ b/tests/unit/reverse-solver.test.js
@@ -17,6 +17,7 @@ import {
     solveForCurrentInvestmentBalance,
     rankLevers,
     scoreLeverFeasibility,
+    ReverseRetirementSolver,
 } from '../../src/js/reverse-solver.js';
 
 // ---------------------------------------------------------------------------
@@ -501,5 +502,66 @@ describe('rankLevers', () => {
         for (let i = 0; i < ranked.length - 1; i++) {
             expect(ranked[i].feasibilityScore).toBeGreaterThanOrEqual(ranked[i + 1].feasibilityScore);
         }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 11. ReverseRetirementSolver.solveAllLevers — integration
+// ---------------------------------------------------------------------------
+
+describe('ReverseRetirementSolver.solveAllLevers', () => {
+    const baseInputs = {
+        yourCurrentAge: 45,
+        retirementAge: 67,
+        yourLifespan: 90,
+        isCouple: false,
+        isSingleCalculation: true,
+        yourSalary: 100000,
+        yourCurrentSuper: 200000,
+        currentSavings: 30000,
+        currentStocks: 0,
+        monthlyStockContribution: 0,
+        yourAdditionalSuperContribution: 0,
+        employerSuperContributionRate: 0.12,
+        inflation: 0.026,
+        superReturn: 0.075,
+        investmentReturn: 0.07,
+        savingsReturn: 0.035,
+        homeowner: true,
+        mortgageBalance: 0,
+        monthlyMortgagePayment: 0,
+        asfaComfortable: 60000,
+    };
+    const target = { targetAnnualIncomeToday: 60000 };
+
+    test('includes investmentBalance in rankedLevers — regression for previously omitted solver', async () => {
+        const { ENHANCED_CONFIG } = require('../../src/js/config.js');
+        const solver = new ReverseRetirementSolver(ENHANCED_CONFIG);
+        const result = await solver.solveAllLevers(baseInputs, target, {});
+        const keys = result.rankedLevers.map((l) => l.lever);
+        expect(keys).toContain('investmentBalance');
+    });
+
+    test('includes all expected lever types in output', async () => {
+        const { ENHANCED_CONFIG } = require('../../src/js/config.js');
+        const solver = new ReverseRetirementSolver(ENHANCED_CONFIG);
+        const result = await solver.solveAllLevers(baseInputs, target, {});
+        const keys = result.rankedLevers.map((l) => l.lever);
+        expect(keys).toContain('extraAnnualSuper');
+        expect(keys).toContain('extraSavings');
+        expect(keys).toContain('salary');
+        expect(keys).toContain('retirementAge');
+        expect(keys).toContain('superBalance');
+        expect(keys).toContain('investmentBalance');
+    });
+
+    test('returns currentScore and currentResult alongside rankedLevers', async () => {
+        const { ENHANCED_CONFIG } = require('../../src/js/config.js');
+        const solver = new ReverseRetirementSolver(ENHANCED_CONFIG);
+        const result = await solver.solveAllLevers(baseInputs, target, {});
+        expect(result).toHaveProperty('currentScore');
+        expect(result).toHaveProperty('currentResult');
+        expect(result).toHaveProperty('rankedLevers');
+        expect(Array.isArray(result.rankedLevers)).toBe(true);
     });
 });

--- a/tests/unit/simulator-stochastic-rate.test.js
+++ b/tests/unit/simulator-stochastic-rate.test.js
@@ -6,13 +6,16 @@ describe('stochasticRate', () => {
         expect(stochasticRate(0.026, false, 0.005)).toBe(0.026);
     });
 
-    test('stays within ±4pp band and respects floor in stochastic mode', () => {
+    test('uses caller-provided sigma and respects the lower floor', () => {
+        const fourSigmaTail = Math.exp(-8);
         const randomSpy = jest.spyOn(Math, 'random')
-            .mockReturnValueOnce(0) // lowest draw => -4pp perturbation
-            .mockReturnValueOnce(1); // highest draw => +4pp perturbation
+            .mockReturnValueOnce(fourSigmaTail)
+            .mockReturnValueOnce(0.5)
+            .mockReturnValueOnce(fourSigmaTail)
+            .mockReturnValueOnce(0);
 
-        expect(stochasticRate(0.03, true, 0.005)).toBe(0.005); // floored from -1%
-        expect(stochasticRate(0.03, true, 0.005)).toBeCloseTo(0.07, 10);
+        expect(stochasticRate(0.03, true, 0.005, 0.01)).toBe(0.005);
+        expect(stochasticRate(0.03, true, 0.005, 0.01)).toBeCloseTo(0.07, 10);
 
         randomSpy.mockRestore();
     });

--- a/tests/unit/simulator-stochastic-rate.test.js
+++ b/tests/unit/simulator-stochastic-rate.test.js
@@ -1,4 +1,7 @@
-import RetirementSimulator, { stochasticRate } from '../../src/js/simulator.js';
+import RetirementSimulator, {
+    stochasticRate,
+    stochasticSigmaForRate,
+} from '../../src/js/simulator.js';
 import ENHANCED_CONFIG from '../../src/js/config.js';
 
 describe('stochasticRate', () => {
@@ -16,6 +19,22 @@ describe('stochasticRate', () => {
 
         expect(stochasticRate(0.03, true, 0.005, 0.01)).toBe(0.005);
         expect(stochasticRate(0.03, true, 0.005, 0.01)).toBeCloseTo(0.07, 10);
+
+        randomSpy.mockRestore();
+    });
+
+    test('uses type-specific volatility consistent with the shared engines', () => {
+        expect(stochasticSigmaForRate(0.026, 'inflation')).toBeCloseTo(0.0104, 10);
+        expect(stochasticSigmaForRate(0.075, 'super')).toBeCloseTo(0.045, 10);
+        expect(stochasticSigmaForRate(0.014, 'savings')).toBeCloseTo(0.005, 10);
+    });
+
+    test('allows negative super years while retaining the configured loss floor', () => {
+        const randomSpy = jest.spyOn(Math, 'random')
+            .mockReturnValueOnce(Math.exp(-8))
+            .mockReturnValueOnce(0.5);
+
+        expect(stochasticRate(0.075, true, -0.30, 0.045)).toBeCloseTo(-0.105, 10);
 
         randomSpy.mockRestore();
     });


### PR DESCRIPTION
## Summary

Completes the calculator consolidation work on this branch by fixing two pre-existing solver defects, adding the Reverse Scenario Builder feature, and covering everything with regression tests.

### Fix: `solveAllLevers` omission (`reverse-solver.js`)
- `solveForCurrentInvestmentBalance()` was fully implemented but never called in `solveAllLevers()`, making the *required non-super investments* lever always missing from reverse planner output.
- Restored to the parallel `Promise.all()` execution set alongside `superBalance`, `salary`, and `extraSavings`.

### Fix: missing couple fields in `normaliseReversePlannerInputs` (`reverse-planner.js`)
- `partnerCurrentAge`, `partnerRetirementAge`, and `partnerLifespan` were not normalised for couple scenarios, causing solver inputs to lack partner timing data.

### Feat: Reverse Scenario Builder (`reverse.html`, `reverse-ui.js`, `reverse-scenario-engine.js`)
- New top section on `reverse.html`: *Scenario Builder — What do we need today?*
- Accepts household type, current ages, retirement age, target after-tax income, confidence target, lifespan, home status, and 8 funding-source toggles (super, age pension, non-super investments, investment property, downsizing, aged care, overseas retirement).
- `ReverseScenarioEngine` builds 10 comparison paths and calls `ReverseRetirementSolver.solveAllLevers()` per scenario, mapping results to required super, required non-super investments, required gross salary, required monthly surplus, required salary sacrifice, expected age pension, assets at retirement, and estate at lifespan.
- Results table rendered in the page and included in PDF export.
- Deterministic lever values shown immediately; UI warns that confidence targets require Monte Carlo validation.
- Scenario name in HTML results table uses `escapeHtml()` for defense-in-depth.

### Tests (1122 → 1132 tests, all passing)
- `reverse-solver.test.js`: regression test that `investmentBalance` is present in `solveAllLevers` output; tests all expected lever types; tests `currentScore`/`currentResult` presence.
- `reverse-scenario-engine.test.js` (new, 10 tests): scenario definition count; all $84k couple paths present; super-off zeroes balances and contributions; `noCurrentAssets` zeroes all starting balances; property-retained preserves values and omits `sellPropertyYears`; property-sold sets `sellPropertyYears`; aged-care-on sets defaults; aged-care-off zeroes cost; stress reduces returns and raises inflation; solver output columns map correctly.

## Test plan

- [x] `npm test` — 1132 tests pass, 55 suites
- [x] `npm run build` — webpack compiles all three bundles without errors
- [x] Manual: open `reverse.html`, fill in scenario builder, click *Compare what we need today*, verify table renders
- [x] Manual: run existing reverse planner with and without imported forward projection
- [x] Manual: export PDF — verify scenario builder section appears

## Confidence ratings (per changed file)
| File | Rating | Notes |
|------|--------|-------|
| `reverse-solver.js` | 9/10 | Targeted 3-line fix for a confirmed omission |
| `reverse-planner.js` | 9/10 | Adds missing couple fields, consistent with existing pattern |
| `reverse-scenario-engine.js` | 8/10 | New module; all config fields verified in `ENHANCED_CONFIG` |
| `reverse.html` | 9/10 | IDs match JS; defaults set to $84k couple example |
| `reverse-ui.js` | 8/10 | Handler flow verified; `escapeHtml` applied to scenario name |
| `reverse-scenario-engine.test.js` | 8/10 | Covers all scenario toggle branches |
| `reverse-solver.test.js` | 8/10 | Uses existing mock; regression guards the solver restoration |
