### PR TITLE
Fix accumulation loop exit and improve input handling

### DIFF
--- a/src/js/reverse-baseline-adapter.js
+++ b/src/js/reverse-baseline-adapter.js
@@ -198,6 +198,9 @@ export function buildReverseBaselineFromForwardScenario(raw) {
             annualPropertyExpenses: num(isV2 ? raw.ipAnnualExpenses : (raw.annualPropertyExpenses ?? raw.ipAnnualExpenses), 0),
             propertyGrowthRate: num(isV2 ? raw.ipGrowthRate : (raw.propertyGrowthRate ?? raw.ipGrowthRate), 0.04),
 
+            // Healthcare
+            healthcareCost: num(isV2 ? raw.healthcareCost : (raw.healthcareCost ?? raw.currentHealthcareCosts), 4800),
+
             // Economic assumptions
             inflation: num(isV2 ? raw.inflation : (raw.inflation ?? 0), 0.026),
             investmentReturn: num(isV2 ? raw.invReturn : (raw.investmentReturn ?? raw.invReturn ?? 0), 0.07),

--- a/src/js/reverse-ui.js
+++ b/src/js/reverse-ui.js
@@ -373,10 +373,6 @@ export class ReverseUI {
         document.querySelectorAll('.section-head').forEach((head) => {
             head.addEventListener('click', () => {
                 const section = head.closest('.section');
-        if (!gaps || gaps.length === 0) {
-            console.warn('No gaps available for task suggestion');
-            return;
-        }
                 const wasOpen = section.classList.contains('open');
                 document.querySelectorAll('.section').forEach((s) => {
                     s.classList.remove('open');
@@ -463,6 +459,23 @@ export class ReverseUI {
      */
     _populateFromBaseline(baseline) {
         this.importedScenario = baseline.inputs;
+
+        // Populate form fields that are read directly from the DOM (not covered by
+        // _collectFromBaseline) so they reflect imported values rather than HTML defaults.
+        const i = baseline.inputs || {};
+        const setField = (id, value) => {
+            const elem = el(id);
+            if (elem && value !== undefined && value !== null) {
+                elem.value = String(value);
+            }
+        };
+
+        // Healthcare cost: field default is 4800 but imported value may differ.
+        const healthcareCost = i.healthcareCost ?? i.currentHealthcareCosts;
+        if (healthcareCost !== undefined) setField('rp-healthcare-cost', Math.round(healthcareCost));
+
+        // Trigger the spending builder to recalculate with the newly populated values.
+        this._updateSpendingTargetBuilder();
     }
 
     /**

--- a/src/js/simulator.js
+++ b/src/js/simulator.js
@@ -1604,6 +1604,15 @@ export class RetirementSimulator {
                 }
             }
 
+            // Stop accumulation phase when the primary person reaches retirement.
+            // This must happen BEFORE any growth/contribution calculation below so the
+            // retirement loop is not double-charged an extra year of compounding on the
+            // opening super balance.  The retirement loop owns all growth and withdrawals
+            // from retirementAge onward.
+            if (yourCurrentAge > inputs.retirementAge) {
+                break;
+            }
+
             // Per-year inflation draw: each accumulation year draws a fresh rate from
             // stochasticRate() centred on the user's input (median).  The cumulative
             // factor replaces Math.pow(1 + runInflationRate, year) throughout, giving
@@ -1662,7 +1671,7 @@ export class RetirementSimulator {
                     allocation,
                     baseReturn,
                     year,
-                    inputs.returnDeclineRate || 0.0003,
+                    inputs.returnDeclineRate ?? 0.0003,
                     true,
                     this.previousReturns.portfolio
                 );
@@ -1673,7 +1682,7 @@ export class RetirementSimulator {
                     allocation,
                     baseReturn,
                     year,
-                    inputs.returnDeclineRate || 0.0003,
+                    inputs.returnDeclineRate ?? 0.0003,
                     false
                 );
             }
@@ -2050,17 +2059,14 @@ export class RetirementSimulator {
                 inputs.healthcareInflation
             );
             healthcareCostHistory.push(healthcareCost);
-            if (yourCurrentAge <= inputs.retirementAge) {
-                const totalAssetsNow = accumulatedSuperBalance + accumulatedSavingsBalance + accumulatedInvestmentPortfolio + getHomeEquityAtYear(year) + propertyEquity;
-                if (totalAssetsNow > peakWealth) {
-                    peakWealth = totalAssetsNow;
-                    peakWealthAge = yourCurrentAge;
-                }
-                pushAccumulationSnapshot(year, yourCurrentAge, propertyEquity);
+            // Retirement age is checked at the top of the loop now; every iteration here
+            // is a legitimate accumulation year (yourCurrentAge ≤ retirementAge).
+            const totalAssetsNow = accumulatedSuperBalance + accumulatedSavingsBalance + accumulatedInvestmentPortfolio + getHomeEquityAtYear(year) + propertyEquity;
+            if (totalAssetsNow > peakWealth) {
+                peakWealth = totalAssetsNow;
+                peakWealthAge = yourCurrentAge;
             }
-            if (yourCurrentAge > inputs.retirementAge) {
-                break;
-            }
+            pushAccumulationSnapshot(year, yourCurrentAge, propertyEquity);
         }
 
         // At retirement setup
@@ -2638,7 +2644,7 @@ export class RetirementSimulator {
                     allocation,
                     baseReturn,
                     retirementYear,
-                    inputs.returnDeclineRate || 0.0003,
+                    inputs.returnDeclineRate ?? 0.0003,
                     true,
                     this.previousReturns.portfolio
                 );
@@ -2675,7 +2681,7 @@ export class RetirementSimulator {
                     allocation,
                     baseReturn,
                     retirementYear,
-                    inputs.returnDeclineRate || 0.0003,
+                    inputs.returnDeclineRate ?? 0.0003,
                     false
                 );
             }

--- a/tests/integration/reverse-integration.test.js
+++ b/tests/integration/reverse-integration.test.js
@@ -243,7 +243,10 @@ describe('bisectionSolve with real simulator', () => {
 // ---------------------------------------------------------------------------
 
 describe('scoreScenario monotonicity', () => {
-    test('higher totalFinancialAssets gives higher sustainableIncomeToday', () => {
+    test('higher totalFinancialAssets gives higher swrCapacityToday', () => {
+        // sustainableIncomeToday now reflects plannedSpendingToday (actual modelled spend),
+        // which may not change with asset level. swrCapacityToday = assets × 4% + pension
+        // retains the strictly-monotone relationship with assets.
         const target = { targetAnnualIncomeToday: 50000 };
         const ytr = 20;
 
@@ -253,7 +256,7 @@ describe('scoreScenario monotonicity', () => {
         const lowScore = scoreScenario(lowResult, target, 0.026, ytr, 0.04);
         const highScore = scoreScenario(highResult, target, 0.026, ytr, 0.04);
 
-        expect(highScore.sustainableIncomeToday).toBeGreaterThan(lowScore.sustainableIncomeToday);
+        expect(highScore.swrCapacityToday).toBeGreaterThan(lowScore.swrCapacityToday);
     });
 });
 

--- a/tests/unit/reconciliation.test.js
+++ b/tests/unit/reconciliation.test.js
@@ -154,12 +154,16 @@ describe('Engine Reconciliation vs Oracle', () => {
     // - Single
     // - Standard returns
     test('Baseline Persona: Engine stays within 5% of Oracle', () => {
+        // salaryGrowthRate pinned to 0 so oracle (fixed salary) and engine (no growth) are comparable.
+        // Without this pin, the engine default 2%/yr salary growth raises SG contributions by ~18%
+        // above the flat-salary oracle — not an engine bug, just an apples-to-oranges comparison.
         const inputs = {
             household: 'single',
             age: 45,
             retireAge: 65,
             lifespan: 90,
             salary: 100000,
+            salaryGrowthRate: 0,
             superBal: 150000,
             inflation: 2.5,
             superGrowth: 7.5,
@@ -169,7 +173,7 @@ describe('Engine Reconciliation vs Oracle', () => {
         };
 
         const result = simulator.simulateRetirement(inputs, false);
-        
+
         const oracle = runOracle({
             startSuper: 150000,
             salary: 100000,

--- a/tests/unit/reverse-solver.test.js
+++ b/tests/unit/reverse-solver.test.js
@@ -181,12 +181,14 @@ describe('scoreScenario', () => {
         expect(score.passesGoal).toBe(false);
     });
 
-    test('returns sustainableIncomeToday as SWR reference', () => {
-        // $2M assets, 4% SWR, no inflation adjustment (0 years)
+    test('returns swrCapacityToday as SWR reference', () => {
+        // $2M assets, 4% SWR, no inflation adjustment (0 years to retirement)
+        // sustainableIncomeToday now returns plannedSpendingToday (actual spending from simulation).
+        // The SWR capacity figure moved to swrCapacityToday: assets × 4% + pension.
         const simResult = { finalBalance: 1_000_000, totalFinancialAssets: 2_000_000, yearlyData: [{ age: 65, pensionIncome: 0 }] };
         const target = { targetAnnualIncomeToday: 80000 };
         const score = scoreScenario(simResult, target, 0.026, 0, 0.04);
-        expect(score.sustainableIncomeToday).toBeCloseTo(80000, -2);
+        expect(score.swrCapacityToday).toBeCloseTo(80000, -2);
     });
 
     test('incomeGap is non-negative', () => {


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in the accumulation phase loop and improves input validation and UI state management across the simulator and reverse planner.

## Key Changes

### Simulator (`src/js/simulator.js`)

- **Fixed accumulation loop exit condition**: Moved the retirement age check to the top of the accumulation loop (before growth/contribution calculations) to prevent double-compounding in the final accumulation year. The retirement loop now correctly owns all growth and withdrawals from `retirementAge` onward.
- **Improved null coalescing**: Replaced `||` with `??` operator for `returnDeclineRate` fallback (4 instances) to correctly handle the case where the input is explicitly `0`.
- **Simplified peak wealth tracking**: Removed redundant conditional logic; peak wealth is now tracked for all accumulation years since the retirement age check happens at loop entry.

### Reverse UI (`src/js/reverse-ui.js`)

- **Fixed section toggle bug**: Removed orphaned code block that was checking `gaps` variable in the wrong context (dead code in section click handler).
- **Enhanced baseline import**: Added explicit population of form fields from imported baseline values, particularly healthcare cost, which now correctly reflects imported values instead of HTML defaults. Triggers spending builder recalculation after import.

### Reverse Baseline Adapter (`src/js/reverse-baseline-adapter.js`)

- **Added healthcare cost mapping**: Ensures healthcare cost is properly mapped from forward scenario to reverse baseline, supporting both v2 and legacy field names.

### Tests

- **Updated test expectations**: Renamed `sustainableIncomeToday` references to `swrCapacityToday` in reverse solver tests to reflect the semantic change (SWR capacity = assets × 4% + pension, distinct from actual planned spending).
- **Added test documentation**: Clarified that `swrCapacityToday` maintains strict monotonicity with asset level, unlike `sustainableIncomeToday` which reflects actual modelled spending.
- **Fixed reconciliation test**: Pinned `salaryGrowthRate` to 0 in baseline persona test to ensure apples-to-apples comparison with oracle (fixed salary), preventing ~18% variance from engine's default 2% annual growth.

## Implementation Details

The accumulation loop fix ensures that when a person reaches retirement age, the loop exits *before* applying that year's growth and contributions. This prevents the final accumulation year from being double-counted (once in accumulation, once in retirement phase). The retirement loop is now the sole owner of all financial activity from `retirementAge` onward.

The null coalescing operator change (`??` instead of `||`) is important for `returnDeclineRate` because a value of `0` is valid and should not fall back to the default `0.0003`.
